### PR TITLE
feat: staking operations (add, remove, list)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes 0.14.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1378,12 +1382,19 @@ dependencies = [
 name = "btt"
 version = "0.1.0"
 dependencies = [
+ "bip39",
  "clap",
+ "hex",
+ "rand 0.8.5",
+ "rpassword",
+ "scrypt",
  "serde",
  "serde_json",
  "sp-core",
  "subxt",
  "tokio",
+ "xsalsa20poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1509,6 +1520,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -6748,6 +6760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
+ "hmac 0.12.1",
  "password-hash",
 ]
 
@@ -7956,6 +7969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8185,6 +8208,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -8463,6 +8495,18 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "sec1"
@@ -11940,6 +11984,19 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a6dad357567f81cd78ee75f7c61f1b30bb2fe4390be8fb7c69e2ac8dffb6c7"
+dependencies = [
+ "aead",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,11 @@ tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sp-core = { version = "34", default-features = false }
+sp-core = { version = "34", default-features = false, features = ["std"] }
+bip39 = { version = "2", features = ["rand"] }
+rpassword = "5"
+zeroize = { version = "1", features = ["derive"] }
+xsalsa20poly1305 = "0.9"
+scrypt = "0.11"
+rand = "0.8"
+hex = "0.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,12 @@ pub enum Command {
         action: WalletAction,
     },
 
+    /// Staking operations
+    Stake {
+        #[command(subcommand)]
+        action: StakeAction,
+    },
+
     /// Emit SKILL.md for AI agent integration
     Skill,
 }
@@ -57,4 +63,146 @@ pub enum ChainAction {
 pub enum WalletAction {
     /// List wallets in ~/.bittensor/wallets/
     List,
+
+    /// Create a new wallet (coldkey + hotkey pair)
+    Create {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Hotkey name
+        #[arg(long, default_value = "default")]
+        hotkey: String,
+        /// Number of mnemonic words (12 or 24)
+        #[arg(long, default_value_t = 12)]
+        n_words: u32,
+    },
+
+    /// Generate a new coldkey only
+    NewColdkey {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Number of mnemonic words (12 or 24)
+        #[arg(long, default_value_t = 12)]
+        n_words: u32,
+    },
+
+    /// Generate a new hotkey for an existing wallet
+    NewHotkey {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Hotkey name
+        #[arg(long, default_value = "default")]
+        hotkey: String,
+        /// Number of mnemonic words (12 or 24)
+        #[arg(long, default_value_t = 12)]
+        n_words: u32,
+    },
+
+    /// Restore a coldkey from mnemonic or seed
+    RegenColdkey {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// BIP39 mnemonic phrase
+        #[arg(long)]
+        mnemonic: Option<String>,
+        /// Hex-encoded seed (0x...)
+        #[arg(long)]
+        seed: Option<String>,
+    },
+
+    /// Restore a hotkey from mnemonic or seed
+    RegenHotkey {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Hotkey name
+        #[arg(long, default_value = "default")]
+        hotkey: String,
+        /// BIP39 mnemonic phrase
+        #[arg(long)]
+        mnemonic: Option<String>,
+        /// Hex-encoded seed (0x...)
+        #[arg(long)]
+        seed: Option<String>,
+    },
+
+    /// Sign a message with a wallet key
+    Sign {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Hotkey name (when using --use-hotkey)
+        #[arg(long, default_value = "default")]
+        hotkey: String,
+        /// Message to sign
+        #[arg(long)]
+        message: String,
+        /// Sign with hotkey instead of coldkey
+        #[arg(long, default_value_t = false)]
+        use_hotkey: bool,
+    },
+
+    /// Verify a signature
+    Verify {
+        /// Message that was signed
+        #[arg(long)]
+        message: String,
+        /// Hex-encoded signature (0x...)
+        #[arg(long)]
+        signature: String,
+        /// SS58 address of the signer
+        #[arg(long)]
+        ss58: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum StakeAction {
+    /// List all stakes for a wallet
+    List {
+        /// Wallet name (reads coldkeypub.txt for the SS58 address)
+        #[arg(long)]
+        wallet: Option<String>,
+        /// SS58 address to query directly (alternative to --wallet)
+        #[arg(long)]
+        ss58: Option<String>,
+    },
+
+    /// Stake TAO from coldkey to hotkey on a subnet
+    Add {
+        /// Wallet name (coldkey will be decrypted for signing)
+        #[arg(long)]
+        wallet: String,
+        /// Hotkey SS58 address to stake to
+        #[arg(long)]
+        hotkey: String,
+        /// Subnet ID
+        #[arg(long)]
+        netuid: u16,
+        /// Amount in TAO (e.g. 10.5)
+        #[arg(long)]
+        amount: f64,
+    },
+
+    /// Unstake TAO from hotkey back to coldkey
+    Remove {
+        /// Wallet name (coldkey will be decrypted for signing)
+        #[arg(long)]
+        wallet: String,
+        /// Hotkey SS58 address to unstake from
+        #[arg(long)]
+        hotkey: String,
+        /// Subnet ID
+        #[arg(long)]
+        netuid: u16,
+        /// Amount in TAO (e.g. 10.5). Ignored if --all is set.
+        #[arg(long, required_unless_present = "all")]
+        amount: Option<f64>,
+        /// Unstake all TAO from this hotkey on this subnet
+        #[arg(long, default_value_t = false)]
+        all: bool,
+    },
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,5 @@
 pub mod chain;
 pub mod skill;
+pub mod stake;
 pub mod wallet;
+pub mod wallet_keys;

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -39,6 +39,21 @@ btt chain balance <ss58_address>
 btt wallet list
 ```
 
+### Stake
+
+```bash
+# List all stakes for a wallet
+btt stake list --wallet <name>
+btt stake list --ss58 <address>
+
+# Add stake (TAO from coldkey to hotkey on a subnet)
+btt stake add --wallet <name> --hotkey <ss58> --netuid <u16> --amount <TAO>
+
+# Remove stake (unstake TAO from hotkey back to coldkey)
+btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --amount <TAO>
+btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --all
+```
+
 ### Skill
 
 ```bash

--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -1,0 +1,536 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use sp_core::crypto::Ss58Codec;
+use sp_core::sr25519;
+use sp_core::Pair as PairTrait;
+use subxt::dynamic::{At, Value};
+use subxt::tx::PairSigner;
+use subxt::PolkadotConfig;
+
+use crate::commands::chain::parse_ss58;
+use crate::commands::wallet_keys::{
+    decrypt_coldkey_interactive, rao_to_tao_string, resolve_coldkey_address, tao_to_rao,
+};
+use crate::error::BttError;
+use crate::rpc;
+
+/// Timeout for staking RPC operations.
+const RPC_TIMEOUT: Duration = rpc::RPC_TIMEOUT;
+
+// ── Output types ──────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct StakeListResult {
+    pub address: String,
+    pub stakes: Vec<StakeEntry>,
+}
+
+#[derive(Serialize)]
+pub struct StakeEntry {
+    pub hotkey: String,
+    pub netuid: u16,
+    pub stake_tao: String,
+}
+
+#[derive(Serialize)]
+pub struct StakeTxResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub action: String,
+    pub amount_tao: String,
+    pub hotkey: String,
+    pub netuid: u16,
+}
+
+// ── Commands ──────────────────────────────────────────────────────────────
+
+/// List all stakes for a coldkey address.
+///
+/// Uses the `SubtensorModule::Alpha` storage map to enumerate stakes.
+/// The Alpha storage is a triple map keyed by (hotkey, coldkey, netuid).
+/// Since we cannot efficiently iterate a triple map by coldkey alone via
+/// the dynamic API without knowing all hotkeys and netuids, we use the
+/// runtime API `SubnetInfoRuntimeApi::get_stake_info_for_coldkey` via
+/// `state_call` if available, falling back to the `SubtensorModule::Stake`
+/// double map (hotkey, coldkey) which gives total stake per hotkey.
+pub async fn list(
+    endpoint: &str,
+    wallet: Option<&str>,
+    ss58: Option<&str>,
+) -> Result<StakeListResult, BttError> {
+    let address = resolve_address(wallet, ss58)?;
+    let account_bytes = parse_ss58(&address)?;
+
+    let api = rpc::connect(endpoint).await?;
+
+    // Query the on-chain storage to find all stakes for this coldkey.
+    // Strategy: use StakingHotkeys to get the list of hotkeys this coldkey
+    // has staked to, then query Alpha for each (hotkey, coldkey, netuid).
+    // We iterate over partial keys. This may not return netuid-level granularity,
+    // but it gives us the hotkey-level stake amounts.
+    let storage = tokio::time::timeout(RPC_TIMEOUT, api.storage().at_latest())
+        .await
+        .map_err(|_| BttError::query("storage query timed out"))?
+        .map_err(|e| BttError::query(format!("failed to get storage: {e}")))?;
+
+    // First approach: try SubtensorModule.Stake partial key iteration
+    // SubtensorModule::Stake is a double map (hotkey, coldkey) -> u64
+    // We can't efficiently query by coldkey (second key) with partial iteration.
+    //
+    // Alternative: SubtensorModule::TotalHotkeyStake (map: hotkey -> u64)
+    // or SubtensorModule::StakingHotkeys (map: coldkey -> Vec<hotkey>)
+    //
+    // Best approach for coldkey lookup: use StakingHotkeys to get the list of hotkeys
+    // this coldkey has staked to, then query Alpha for each (hotkey, coldkey, netuid).
+
+    let staking_hotkeys_query = subxt::dynamic::storage(
+        "SubtensorModule",
+        "StakingHotkeys",
+        vec![Value::from_bytes(account_bytes.clone())],
+    );
+
+    let mut stakes = Vec::new();
+
+    let staking_hotkeys_result = tokio::time::timeout(
+        RPC_TIMEOUT,
+        storage.fetch(&staking_hotkeys_query),
+    )
+    .await
+    .map_err(|_| BttError::query("StakingHotkeys fetch timed out"))?
+    .map_err(|e| BttError::query(format!("failed to fetch StakingHotkeys: {e}")))?;
+
+    if let Some(value) = staking_hotkeys_result {
+        let decoded = value
+            .to_value()
+            .map_err(|e| BttError::parse(format!("failed to decode StakingHotkeys: {e}")))?;
+
+        // The decoded value is a Composite (sequence of AccountId32).
+        // Each element is itself a composite of 32 u8 values.
+        // Extract them by iterating with .at(index).
+        let hotkey_list = extract_account_ids(&decoded);
+
+        // For each hotkey, query Alpha storage for all netuids.
+        // Alpha is a triple map: (hotkey, coldkey, netuid) -> u64
+        // We iterate over netuids 0..64 (reasonable upper bound for subnet count).
+        for hotkey_bytes in &hotkey_list {
+            let hotkey_ss58 = sp_core::crypto::AccountId32::new(*hotkey_bytes)
+                .to_ss58check();
+
+            for netuid in 0..64u16 {
+                let alpha_query = subxt::dynamic::storage(
+                    "SubtensorModule",
+                    "Alpha",
+                    vec![
+                        Value::from_bytes(*hotkey_bytes),
+                        Value::from_bytes(account_bytes.clone()),
+                        Value::u128(netuid as u128),
+                    ],
+                );
+
+                if let Ok(Some(val)) = storage.fetch(&alpha_query).await {
+                    if let Ok(dv) = val.to_value() {
+                        if let Some(amount) = dv.as_u128() {
+                            if amount > 0 {
+                                stakes.push(StakeEntry {
+                                    hotkey: hotkey_ss58.clone(),
+                                    netuid,
+                                    stake_tao: rao_to_tao_string(amount as u64),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // If we got no results from Alpha, try the simpler Stake storage
+    // (double map: hotkey, coldkey -> u64, no netuid granularity)
+    if stakes.is_empty() {
+        if let Some(value) = staking_hotkeys_result_fallback(
+            &storage,
+            &account_bytes,
+        )
+        .await?
+        {
+            stakes = value;
+        }
+    }
+
+    Ok(StakeListResult {
+        address,
+        stakes,
+    })
+}
+
+/// Fallback: query SubtensorModule::Stake for each hotkey found in StakingHotkeys.
+async fn staking_hotkeys_result_fallback(
+    storage: &subxt::storage::Storage<PolkadotConfig, subxt::OnlineClient<PolkadotConfig>>,
+    account_bytes: &[u8],
+) -> Result<Option<Vec<StakeEntry>>, BttError> {
+    // Re-fetch StakingHotkeys
+    let staking_hotkeys_query = subxt::dynamic::storage(
+        "SubtensorModule",
+        "StakingHotkeys",
+        vec![Value::from_bytes(account_bytes)],
+    );
+
+    let result = storage
+        .fetch(&staking_hotkeys_query)
+        .await
+        .map_err(|e| BttError::query(format!("failed to fetch StakingHotkeys: {e}")))?;
+
+    let value = match result {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    let decoded = value
+        .to_value()
+        .map_err(|e| BttError::parse(format!("failed to decode StakingHotkeys: {e}")))?;
+
+    let hotkey_list = extract_account_ids(&decoded);
+
+    let mut stakes = Vec::new();
+    for hotkey_bytes in &hotkey_list {
+        let hotkey_ss58 =
+            sp_core::crypto::AccountId32::new(*hotkey_bytes).to_ss58check();
+
+        let stake_query = subxt::dynamic::storage(
+            "SubtensorModule",
+            "Stake",
+            vec![
+                Value::from_bytes(hotkey_bytes),
+                Value::from_bytes(account_bytes),
+            ],
+        );
+
+        if let Ok(Some(val)) = storage.fetch(&stake_query).await {
+            if let Ok(dv) = val.to_value() {
+                if let Some(amount) = dv.as_u128() {
+                    if amount > 0 {
+                        stakes.push(StakeEntry {
+                            hotkey: hotkey_ss58,
+                            netuid: 0, // No netuid info in Stake storage
+                            stake_tao: rao_to_tao_string(amount as u64),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    if stakes.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(stakes))
+    }
+}
+
+/// Add stake from coldkey to hotkey on a specific subnet.
+///
+/// Constructs and submits a `SubtensorModule::add_stake(hotkey, netuid, amount_rao)`
+/// extrinsic signed by the coldkey.
+pub async fn add(
+    endpoint: &str,
+    wallet: &str,
+    hotkey: &str,
+    netuid: u16,
+    amount_tao: f64,
+) -> Result<StakeTxResult, BttError> {
+    let amount_rao = tao_to_rao(amount_tao)?;
+    if amount_rao == 0 {
+        return Err(BttError::invalid_amount("stake amount must be greater than zero"));
+    }
+
+    let hotkey_bytes = parse_ss58(hotkey)?;
+
+    // Decrypt coldkey
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let signer = PairSigner::<PolkadotConfig, sr25519::Pair>::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    // Construct the extrinsic
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "add_stake",
+        vec![
+            Value::from_bytes(hotkey_bytes),
+            Value::u128(netuid as u128),
+            Value::u128(amount_rao as u128),
+        ],
+    );
+
+    // Sign and submit, then wait for inclusion
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        api.tx().sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(
+        Duration::from_secs(120),
+        progress.wait_for_finalized(),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    // Check for success
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(StakeTxResult {
+        tx_hash,
+        block: block_hash,
+        action: "add_stake".to_string(),
+        amount_tao: rao_to_tao_string(amount_rao),
+        hotkey: hotkey.to_string(),
+        netuid,
+    })
+}
+
+/// Remove stake from hotkey back to coldkey on a specific subnet.
+///
+/// Constructs and submits a `SubtensorModule::remove_stake(hotkey, netuid, amount_rao)`
+/// extrinsic signed by the coldkey.
+///
+/// If `unstake_all` is true, queries the current stake and unstakes the full amount.
+pub async fn remove(
+    endpoint: &str,
+    wallet: &str,
+    hotkey: &str,
+    netuid: u16,
+    amount_tao: Option<f64>,
+    unstake_all: bool,
+) -> Result<StakeTxResult, BttError> {
+    let hotkey_bytes = parse_ss58(hotkey)?;
+
+    // Decrypt coldkey
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let coldkey_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_ss58check();
+    let coldkey_bytes = parse_ss58(&coldkey_ss58)?;
+    let signer = PairSigner::<PolkadotConfig, sr25519::Pair>::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let amount_rao = if unstake_all {
+        // Query current stake to determine full amount
+        let storage = tokio::time::timeout(RPC_TIMEOUT, api.storage().at_latest())
+            .await
+            .map_err(|_| BttError::query("storage query timed out"))?
+            .map_err(|e| BttError::query(format!("failed to get storage: {e}")))?;
+
+        // Try Alpha first (triple map with netuid)
+        let alpha_query = subxt::dynamic::storage(
+            "SubtensorModule",
+            "Alpha",
+            vec![
+                Value::from_bytes(hotkey_bytes.clone()),
+                Value::from_bytes(coldkey_bytes.clone()),
+                Value::u128(netuid as u128),
+            ],
+        );
+
+        let mut found_amount: u64 = 0;
+
+        if let Ok(Some(val)) = storage.fetch(&alpha_query).await {
+            if let Ok(dv) = val.to_value() {
+                if let Some(amount) = dv.as_u128() {
+                    found_amount = amount as u64;
+                }
+            }
+        }
+
+        // Fallback: try Stake storage (no netuid)
+        if found_amount == 0 {
+            let stake_query = subxt::dynamic::storage(
+                "SubtensorModule",
+                "Stake",
+                vec![
+                    Value::from_bytes(hotkey_bytes.clone()),
+                    Value::from_bytes(coldkey_bytes),
+                ],
+            );
+
+            if let Ok(Some(val)) = storage.fetch(&stake_query).await {
+                if let Ok(dv) = val.to_value() {
+                    if let Some(amount) = dv.as_u128() {
+                        found_amount = amount as u64;
+                    }
+                }
+            }
+        }
+
+        if found_amount == 0 {
+            return Err(BttError::invalid_amount(
+                "no stake found for this hotkey/netuid combination",
+            ));
+        }
+
+        found_amount
+    } else {
+        let tao = amount_tao.ok_or_else(|| {
+            BttError::invalid_amount("--amount is required unless --all is specified")
+        })?;
+        let rao = tao_to_rao(tao)?;
+        if rao == 0 {
+            return Err(BttError::invalid_amount("unstake amount must be greater than zero"));
+        }
+        rao
+    };
+
+    // Construct the extrinsic
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "remove_stake",
+        vec![
+            Value::from_bytes(hotkey_bytes),
+            Value::u128(netuid as u128),
+            Value::u128(amount_rao as u128),
+        ],
+    );
+
+    // Sign and submit
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        api.tx().sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(
+        Duration::from_secs(120),
+        progress.wait_for_finalized(),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(StakeTxResult {
+        tx_hash,
+        block: block_hash,
+        action: "remove_stake".to_string(),
+        amount_tao: rao_to_tao_string(amount_rao),
+        hotkey: hotkey.to_string(),
+        netuid,
+    })
+}
+
+/// Extract a list of 32-byte AccountId arrays from a decoded dynamic Value.
+///
+/// The Value from `StakingHotkeys` is a Composite (sequence) where each element
+/// is either:
+/// - A Composite of 32 u8 values (the AccountId32 bytes), or
+/// - A bytes-like value that can be read directly.
+///
+/// We walk the sequence by index and attempt to extract 32 bytes from each element.
+fn extract_account_ids<T>(value: &Value<T>) -> Vec<[u8; 32]> {
+    let mut result = Vec::new();
+    let mut idx = 0usize;
+    while let Some(elem) = value.at(idx) {
+        if let Some(bytes) = extract_32_bytes(elem) {
+            result.push(bytes);
+        }
+        idx += 1;
+    }
+    result
+}
+
+/// Try to extract exactly 32 bytes from a Value.
+/// Handles both Composite (sequence of u8 values) and direct byte representations.
+fn extract_32_bytes<T>(value: &Value<T>) -> Option<[u8; 32]> {
+    // Try as a sequence of u8 values
+    let mut bytes = Vec::with_capacity(32);
+    let mut idx = 0usize;
+    while let Some(v) = value.at(idx) {
+        if let Some(b) = v.as_u128() {
+            if b <= 255 {
+                bytes.push(b as u8);
+            } else {
+                return None;
+            }
+        } else {
+            break;
+        }
+        idx += 1;
+    }
+
+    if bytes.len() == 32 {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        return Some(arr);
+    }
+
+    None
+}
+
+/// Resolve an address from either a wallet name or a direct SS58 string.
+fn resolve_address(wallet: Option<&str>, ss58: Option<&str>) -> Result<String, BttError> {
+    match (wallet, ss58) {
+        (Some(w), None) => resolve_coldkey_address(w),
+        (None, Some(addr)) => {
+            // Validate the SS58 address
+            parse_ss58(addr)?;
+            Ok(addr.to_string())
+        }
+        (Some(_), Some(_)) => Err(BttError::invalid_input(
+            "provide either --wallet or --ss58, not both",
+        )),
+        (None, None) => Err(BttError::invalid_input(
+            "provide either --wallet or --ss58",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_address_ss58_validates() {
+        let valid = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+        let result = resolve_address(None, Some(valid));
+        assert!(result.is_ok());
+        assert_eq!(result.expect("should resolve"), valid);
+    }
+
+    #[test]
+    fn resolve_address_invalid_ss58_fails() {
+        let invalid = "not-an-address";
+        let result = resolve_address(None, Some(invalid));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_address_both_provided_fails() {
+        let result = resolve_address(Some("wallet"), Some("5Grw..."));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_address_neither_provided_fails() {
+        let result = resolve_address(None, None);
+        assert!(result.is_err());
+    }
+}

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -1,0 +1,1032 @@
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use serde::Serialize;
+use sp_core::crypto::{Ss58Codec, Pair as TraitPair};
+use sp_core::sr25519::{Pair, Public, Signature};
+use zeroize::Zeroize;
+
+use crate::error::BttError;
+
+/// One TAO equals 1e9 RAO.
+pub const RAO_PER_TAO: u64 = 1_000_000_000;
+
+/// Convert a TAO amount (floating point) to RAO (integer).
+/// Returns an error if the amount is negative, NaN, infinite, or overflows u64.
+pub fn tao_to_rao(tao: f64) -> Result<u64, BttError> {
+    if tao.is_nan() || tao.is_infinite() {
+        return Err(BttError::invalid_amount("amount must be a finite number"));
+    }
+    if tao < 0.0 {
+        return Err(BttError::invalid_amount("amount must be non-negative"));
+    }
+    let rao_f64 = tao * RAO_PER_TAO as f64;
+    if rao_f64 > u64::MAX as f64 {
+        return Err(BttError::invalid_amount("amount overflows u64 in RAO"));
+    }
+    Ok(rao_f64 as u64)
+}
+
+/// Convert RAO to a human-readable TAO string with up to 9 decimal places.
+/// Trailing zeros are trimmed but at least one decimal place is kept.
+pub fn rao_to_tao_string(rao: u64) -> String {
+    let whole = rao / RAO_PER_TAO;
+    let frac = rao % RAO_PER_TAO;
+    if frac == 0 {
+        format!("{whole}.0")
+    } else {
+        let raw = format!("{whole}.{frac:09}");
+        let trimmed = raw.trim_end_matches('0');
+        trimmed.to_string()
+    }
+}
+
+/// Resolve a coldkey SS58 address from a wallet name.
+/// Reads `~/.bittensor/wallets/<name>/coldkeypub.txt`.
+pub fn resolve_coldkey_address(wallet_name: &str) -> Result<String, BttError> {
+    let wdir = wallet_path(wallet_name)?;
+    if !wdir.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "wallet '{wallet_name}' not found at {}",
+            wdir.display()
+        )));
+    }
+    let pubkey_path = wdir.join("coldkeypub.txt");
+
+    if !pubkey_path.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "coldkeypub.txt not found for wallet '{wallet_name}'"
+        )));
+    }
+
+    let content = fs::read_to_string(&pubkey_path)
+        .map_err(|e| BttError::io(format!("failed to read coldkeypub.txt: {e}")))?;
+
+    extract_ss58_from_content(&content).ok_or_else(|| {
+        BttError::parse(format!(
+            "could not extract SS58 address from coldkeypub.txt for wallet '{wallet_name}'"
+        ))
+    })
+}
+
+/// Decrypt the coldkey for a wallet and return an sr25519 keypair.
+/// Uses the existing load_coldkey infrastructure; prompts for password.
+pub fn decrypt_coldkey_interactive(wallet_name: &str) -> Result<Pair, BttError> {
+    let wdir = wallet_path(wallet_name)?;
+    if !wdir.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "wallet '{wallet_name}' not found at {}",
+            wdir.display()
+        )));
+    }
+
+    let coldkey_path = wdir.join("coldkey");
+    if !coldkey_path.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "coldkey file not found for wallet '{wallet_name}'"
+        )));
+    }
+
+    // Try reading as unencrypted JSON first (development/testing keys)
+    if let Ok(content) = fs::read_to_string(&coldkey_path) {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Ok(pair) = pair_from_key_json(&content) {
+                return Ok(pair);
+            }
+            // Has JSON structure but no usable key fields -- fall through to encrypted path
+            let _ = json;
+        }
+    }
+
+    // Encrypted: prompt for password and decrypt
+    let password = read_password("Enter coldkey password: ")?;
+    let pair = load_coldkey(&wdir, &password)?;
+    Ok(pair)
+}
+
+/// Extract an SS58 address from key file content.
+fn extract_ss58_from_content(content: &str) -> Option<String> {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(content) {
+        if let Some(addr) = v.get("ss58Address").and_then(|v| v.as_str()) {
+            return Some(addr.to_string());
+        }
+        if let Some(addr) = v.get("SS58Address").and_then(|v| v.as_str()) {
+            return Some(addr.to_string());
+        }
+        if let Some(addr) = v.get("address").and_then(|v| v.as_str()) {
+            return Some(addr.to_string());
+        }
+    }
+
+    let trimmed = content.trim();
+    if trimmed.starts_with('5') && trimmed.len() >= 47 && trimmed.len() <= 49 {
+        return Some(trimmed.to_string());
+    }
+
+    None
+}
+
+// btcli uses scrypt with n=2^18, r=8, p=1 for key derivation
+const SCRYPT_LOG_N: u8 = 18;
+const SCRYPT_R: u32 = 8;
+const SCRYPT_P: u32 = 1;
+const SCRYPT_DKLEN: usize = 32;
+
+// NaCl secretbox nonce length
+const NONCE_LEN: usize = 24;
+
+// ── Output types ──────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct CreateResult {
+    pub wallet_name: String,
+    pub coldkey_ss58: String,
+    pub hotkey_ss58: String,
+    pub mnemonic: String,
+}
+
+#[derive(Serialize)]
+pub struct NewColdkeyResult {
+    pub wallet_name: String,
+    pub ss58_address: String,
+    pub mnemonic: String,
+}
+
+#[derive(Serialize)]
+pub struct NewHotkeyResult {
+    pub wallet_name: String,
+    pub hotkey_name: String,
+    pub ss58_address: String,
+    pub mnemonic: String,
+}
+
+#[derive(Serialize)]
+pub struct RegenResult {
+    pub wallet_name: String,
+    pub ss58_address: String,
+}
+
+#[derive(Serialize)]
+pub struct RegenHotkeyResult {
+    pub wallet_name: String,
+    pub hotkey_name: String,
+    pub ss58_address: String,
+}
+
+#[derive(Serialize)]
+pub struct SignResult {
+    pub signature: String,
+    pub public_key: String,
+    pub ss58_address: String,
+}
+
+#[derive(Serialize)]
+pub struct VerifyResult {
+    pub valid: bool,
+}
+
+// ── Key file JSON format (btcli-compatible) ───────────────────────────────
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct KeyFileData {
+    account_id: String,
+    public_key: String,
+    secret_phrase: String,
+    secret_seed: String,
+    ss58_address: String,
+}
+
+// ── Public key file format ────────────────────────────────────────────────
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PubKeyFileData {
+    account_id: String,
+    public_key: String,
+    ss58_address: String,
+}
+
+// ── Core operations ───────────────────────────────────────────────────────
+
+/// Create a new wallet with both coldkey and hotkey.
+pub fn create(
+    wallet_name: &str,
+    hotkey_name: &str,
+    n_words: u32,
+    password: &str,
+) -> Result<CreateResult, BttError> {
+    validate_n_words(n_words)?;
+
+    let (cold_pair, mut cold_phrase, mut cold_seed) = generate_keypair(n_words)?;
+    let cold_ss58 = cold_pair.public().to_ss58check();
+    let cold_seed_hex = format!("0x{}", hex::encode(cold_seed));
+
+    // Build the JSON for the coldkey
+    let cold_json = build_key_json(&cold_pair, &cold_phrase, &cold_seed_hex);
+    let cold_json_str = serde_json::to_string(&cold_json)
+        .map_err(|e| BttError::io(format!("failed to serialize coldkey: {}", e)))?;
+
+    // Encrypt and write coldkey
+    let wallet_dir = wallet_path(wallet_name)?;
+    fs::create_dir_all(&wallet_dir)
+        .map_err(|e| BttError::io(format!("failed to create wallet directory: {}", e)))?;
+
+    let encrypted = encrypt_key_data(cold_json_str.as_bytes(), password)?;
+    write_secure_file(&wallet_dir.join("coldkey"), &encrypted)?;
+
+    // Write coldkeypub.txt (unencrypted public info)
+    let pub_data = build_pub_key_json(&cold_pair);
+    let pub_json_str = serde_json::to_string(&pub_data)
+        .map_err(|e| BttError::io(format!("failed to serialize coldkeypub: {}", e)))?;
+    fs::write(wallet_dir.join("coldkeypub.txt"), &pub_json_str)
+        .map_err(|e| BttError::io(format!("failed to write coldkeypub.txt: {}", e)))?;
+
+    // Generate hotkey
+    let (hot_pair, mut hot_phrase, mut hot_seed) = generate_keypair(n_words)?;
+    let hot_ss58 = hot_pair.public().to_ss58check();
+    let hot_seed_hex = format!("0x{}", hex::encode(hot_seed));
+
+    let hot_json = build_key_json(&hot_pair, &hot_phrase, &hot_seed_hex);
+    let hot_json_str = serde_json::to_string(&hot_json)
+        .map_err(|e| BttError::io(format!("failed to serialize hotkey: {}", e)))?;
+
+    // Write hotkey (unencrypted)
+    let hotkeys_dir = wallet_dir.join("hotkeys");
+    fs::create_dir_all(&hotkeys_dir)
+        .map_err(|e| BttError::io(format!("failed to create hotkeys directory: {}", e)))?;
+    fs::write(hotkeys_dir.join(hotkey_name), &hot_json_str)
+        .map_err(|e| BttError::io(format!("failed to write hotkey: {}", e)))?;
+
+    let mnemonic_out = cold_phrase.clone();
+
+    // Zeroize sensitive material
+    cold_phrase.zeroize();
+    cold_seed.zeroize();
+    hot_phrase.zeroize();
+    hot_seed.zeroize();
+
+    Ok(CreateResult {
+        wallet_name: wallet_name.to_string(),
+        coldkey_ss58: cold_ss58,
+        hotkey_ss58: hot_ss58,
+        mnemonic: mnemonic_out,
+    })
+}
+
+/// Generate only a new coldkey.
+pub fn new_coldkey(
+    wallet_name: &str,
+    n_words: u32,
+    password: &str,
+) -> Result<NewColdkeyResult, BttError> {
+    validate_n_words(n_words)?;
+
+    let (pair, mut phrase, mut seed) = generate_keypair(n_words)?;
+    let ss58 = pair.public().to_ss58check();
+    let seed_hex = format!("0x{}", hex::encode(seed));
+
+    let json = build_key_json(&pair, &phrase, &seed_hex);
+    let json_str = serde_json::to_string(&json)
+        .map_err(|e| BttError::io(format!("failed to serialize coldkey: {}", e)))?;
+
+    let wallet_dir = wallet_path(wallet_name)?;
+    fs::create_dir_all(&wallet_dir)
+        .map_err(|e| BttError::io(format!("failed to create wallet directory: {}", e)))?;
+
+    let encrypted = encrypt_key_data(json_str.as_bytes(), password)?;
+    write_secure_file(&wallet_dir.join("coldkey"), &encrypted)?;
+
+    let pub_data = build_pub_key_json(&pair);
+    let pub_json_str = serde_json::to_string(&pub_data)
+        .map_err(|e| BttError::io(format!("failed to serialize coldkeypub: {}", e)))?;
+    fs::write(wallet_dir.join("coldkeypub.txt"), &pub_json_str)
+        .map_err(|e| BttError::io(format!("failed to write coldkeypub.txt: {}", e)))?;
+
+    let mnemonic_out = phrase.clone();
+
+    phrase.zeroize();
+    seed.zeroize();
+
+    Ok(NewColdkeyResult {
+        wallet_name: wallet_name.to_string(),
+        ss58_address: ss58,
+        mnemonic: mnemonic_out,
+    })
+}
+
+/// Generate a new hotkey for an existing wallet.
+pub fn new_hotkey(
+    wallet_name: &str,
+    hotkey_name: &str,
+    n_words: u32,
+) -> Result<NewHotkeyResult, BttError> {
+    validate_n_words(n_words)?;
+
+    let wallet_dir = wallet_path(wallet_name)?;
+    if !wallet_dir.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "wallet '{}' not found at {}",
+            wallet_name,
+            wallet_dir.display()
+        )));
+    }
+
+    let (pair, mut phrase, mut seed) = generate_keypair(n_words)?;
+    let ss58 = pair.public().to_ss58check();
+    let seed_hex = format!("0x{}", hex::encode(seed));
+
+    let json = build_key_json(&pair, &phrase, &seed_hex);
+    let json_str = serde_json::to_string(&json)
+        .map_err(|e| BttError::io(format!("failed to serialize hotkey: {}", e)))?;
+
+    let hotkeys_dir = wallet_dir.join("hotkeys");
+    fs::create_dir_all(&hotkeys_dir)
+        .map_err(|e| BttError::io(format!("failed to create hotkeys directory: {}", e)))?;
+    fs::write(hotkeys_dir.join(hotkey_name), &json_str)
+        .map_err(|e| BttError::io(format!("failed to write hotkey: {}", e)))?;
+
+    let mnemonic_out = phrase.clone();
+
+    phrase.zeroize();
+    seed.zeroize();
+
+    Ok(NewHotkeyResult {
+        wallet_name: wallet_name.to_string(),
+        hotkey_name: hotkey_name.to_string(),
+        ss58_address: ss58,
+        mnemonic: mnemonic_out,
+    })
+}
+
+/// Restore a coldkey from mnemonic or seed.
+pub fn regen_coldkey(
+    wallet_name: &str,
+    mnemonic: Option<&str>,
+    seed_hex: Option<&str>,
+    password: &str,
+) -> Result<RegenResult, BttError> {
+    let (pair, phrase, seed) = recover_keypair(mnemonic, seed_hex)?;
+    let ss58 = pair.public().to_ss58check();
+    let seed_hex_str = format!("0x{}", hex::encode(seed));
+
+    let json = build_key_json(&pair, &phrase, &seed_hex_str);
+    let json_str = serde_json::to_string(&json)
+        .map_err(|e| BttError::io(format!("failed to serialize coldkey: {}", e)))?;
+
+    let wallet_dir = wallet_path(wallet_name)?;
+    fs::create_dir_all(&wallet_dir)
+        .map_err(|e| BttError::io(format!("failed to create wallet directory: {}", e)))?;
+
+    let encrypted = encrypt_key_data(json_str.as_bytes(), password)?;
+    write_secure_file(&wallet_dir.join("coldkey"), &encrypted)?;
+
+    let pub_data = build_pub_key_json(&pair);
+    let pub_json_str = serde_json::to_string(&pub_data)
+        .map_err(|e| BttError::io(format!("failed to serialize coldkeypub: {}", e)))?;
+    fs::write(wallet_dir.join("coldkeypub.txt"), &pub_json_str)
+        .map_err(|e| BttError::io(format!("failed to write coldkeypub.txt: {}", e)))?;
+
+    Ok(RegenResult {
+        wallet_name: wallet_name.to_string(),
+        ss58_address: ss58,
+    })
+}
+
+/// Restore a hotkey from mnemonic or seed.
+pub fn regen_hotkey(
+    wallet_name: &str,
+    hotkey_name: &str,
+    mnemonic: Option<&str>,
+    seed_hex: Option<&str>,
+) -> Result<RegenHotkeyResult, BttError> {
+    let wallet_dir = wallet_path(wallet_name)?;
+    if !wallet_dir.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "wallet '{}' not found at {}",
+            wallet_name,
+            wallet_dir.display()
+        )));
+    }
+
+    let (pair, phrase, seed) = recover_keypair(mnemonic, seed_hex)?;
+    let ss58 = pair.public().to_ss58check();
+    let seed_hex_str = format!("0x{}", hex::encode(seed));
+
+    let json = build_key_json(&pair, &phrase, &seed_hex_str);
+    let json_str = serde_json::to_string(&json)
+        .map_err(|e| BttError::io(format!("failed to serialize hotkey: {}", e)))?;
+
+    let hotkeys_dir = wallet_dir.join("hotkeys");
+    fs::create_dir_all(&hotkeys_dir)
+        .map_err(|e| BttError::io(format!("failed to create hotkeys directory: {}", e)))?;
+    fs::write(hotkeys_dir.join(hotkey_name), &json_str)
+        .map_err(|e| BttError::io(format!("failed to write hotkey: {}", e)))?;
+
+    Ok(RegenHotkeyResult {
+        wallet_name: wallet_name.to_string(),
+        hotkey_name: hotkey_name.to_string(),
+        ss58_address: ss58,
+    })
+}
+
+/// Sign a message with a key from the wallet.
+pub fn sign(
+    wallet_name: &str,
+    hotkey_name: &str,
+    message: &str,
+    use_hotkey: bool,
+    password: Option<&str>,
+) -> Result<SignResult, BttError> {
+    let wallet_dir = wallet_path(wallet_name)?;
+    if !wallet_dir.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "wallet '{}' not found at {}",
+            wallet_name,
+            wallet_dir.display()
+        )));
+    }
+
+    let pair = if use_hotkey {
+        load_hotkey(&wallet_dir, hotkey_name)?
+    } else {
+        let pw = password
+            .ok_or_else(|| BttError::invalid_input("password required to decrypt coldkey"))?;
+        load_coldkey(&wallet_dir, pw)?
+    };
+
+    let sig = <Pair as TraitPair>::sign(&pair, message.as_bytes());
+    let public = pair.public();
+    let ss58 = public.to_ss58check();
+
+    Ok(SignResult {
+        signature: format!("0x{}", hex::encode(sig.0)),
+        public_key: format!("0x{}", hex::encode(public.0)),
+        ss58_address: ss58,
+    })
+}
+
+/// Verify a signature against a message and SS58 address.
+pub fn verify(message: &str, signature_hex: &str, ss58: &str) -> Result<VerifyResult, BttError> {
+    let public = Public::from_ss58check(ss58)
+        .map_err(|e| BttError::invalid_address(format!("invalid SS58 address: {:?}", e)))?;
+
+    let sig_bytes = parse_hex_bytes(signature_hex)?;
+    if sig_bytes.len() != 64 {
+        return Err(BttError::invalid_input(format!(
+            "signature must be 64 bytes, got {}",
+            sig_bytes.len()
+        )));
+    }
+
+    let mut sig_arr = [0u8; 64];
+    sig_arr.copy_from_slice(&sig_bytes);
+    let signature = Signature::from(sig_arr);
+
+    let valid = <Pair as TraitPair>::verify(&signature, message.as_bytes(), &public);
+
+    Ok(VerifyResult { valid })
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+fn validate_n_words(n: u32) -> Result<(), BttError> {
+    if n != 12 && n != 24 {
+        return Err(BttError::invalid_input(
+            "n-words must be 12 or 24",
+        ));
+    }
+    Ok(())
+}
+
+fn wallet_path(name: &str) -> Result<PathBuf, BttError> {
+    let home =
+        std::env::var("HOME").map_err(|_| BttError::io("HOME environment variable not set"))?;
+    Ok(PathBuf::from(home)
+        .join(".bittensor")
+        .join("wallets")
+        .join(name))
+}
+
+/// Generate an sr25519 keypair with a BIP39 mnemonic of the specified word count.
+fn generate_keypair(n_words: u32) -> Result<(Pair, String, [u8; 32]), BttError> {
+    let mnemonic = bip39::Mnemonic::generate(n_words as usize)
+        .map_err(|e| BttError::crypto(format!("failed to generate mnemonic: {}", e)))?;
+    let phrase = mnemonic.words().collect::<Vec<_>>().join(" ");
+
+    let (pair, seed) = Pair::from_phrase(&phrase, None)
+        .map_err(|e| BttError::crypto(format!("failed to derive keypair from mnemonic: {:?}", e)))?;
+
+    Ok((pair, phrase, seed))
+}
+
+/// Recover a keypair from either a mnemonic phrase or a hex seed.
+fn recover_keypair(
+    mnemonic: Option<&str>,
+    seed_hex: Option<&str>,
+) -> Result<(Pair, String, [u8; 32]), BttError> {
+    match (mnemonic, seed_hex) {
+        (Some(phrase), None) => {
+            let (pair, seed) = Pair::from_phrase(phrase, None).map_err(|e| {
+                BttError::crypto(format!("failed to derive keypair from mnemonic: {:?}", e))
+            })?;
+            Ok((pair, phrase.to_string(), seed))
+        }
+        (None, Some(hex_str)) => {
+            let seed_bytes = parse_hex_bytes(hex_str)?;
+            if seed_bytes.len() != 32 {
+                return Err(BttError::invalid_input(format!(
+                    "seed must be 32 bytes, got {}",
+                    seed_bytes.len()
+                )));
+            }
+            let mut seed = [0u8; 32];
+            seed.copy_from_slice(&seed_bytes);
+            let pair = Pair::from_seed(&seed);
+            Ok((pair, String::new(), seed))
+        }
+        (Some(_), Some(_)) => Err(BttError::invalid_input(
+            "provide either --mnemonic or --seed, not both",
+        )),
+        (None, None) => Err(BttError::invalid_input(
+            "provide either --mnemonic or --seed",
+        )),
+    }
+}
+
+/// Parse a hex string (with optional 0x prefix) into bytes.
+fn parse_hex_bytes(s: &str) -> Result<Vec<u8>, BttError> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    hex::decode(stripped).map_err(|e| BttError::parse(format!("invalid hex: {}", e)))
+}
+
+/// Build the btcli-compatible key JSON structure.
+fn build_key_json(pair: &Pair, phrase: &str, seed_hex: &str) -> KeyFileData {
+    let public = pair.public();
+    KeyFileData {
+        account_id: format!("0x{}", hex::encode(public.0)),
+        public_key: format!("0x{}", hex::encode(public.0)),
+        secret_phrase: phrase.to_string(),
+        secret_seed: seed_hex.to_string(),
+        ss58_address: public.to_ss58check(),
+    }
+}
+
+/// Build public key JSON (for coldkeypub.txt).
+fn build_pub_key_json(pair: &Pair) -> PubKeyFileData {
+    let public = pair.public();
+    PubKeyFileData {
+        account_id: format!("0x{}", hex::encode(public.0)),
+        public_key: format!("0x{}", hex::encode(public.0)),
+        ss58_address: public.to_ss58check(),
+    }
+}
+
+/// Encrypt key data using NaCl secretbox (XSalsa20-Poly1305) with
+/// password-derived key via scrypt. Matches btcli's encryption format.
+fn encrypt_key_data(plaintext: &[u8], password: &str) -> Result<Vec<u8>, BttError> {
+    use rand::RngCore;
+    use scrypt::scrypt;
+    use xsalsa20poly1305::aead::Aead;
+    use xsalsa20poly1305::{KeyInit, XSalsa20Poly1305};
+
+    // Derive key from password using scrypt
+    let mut salt = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut salt);
+
+    let params = scrypt::Params::new(SCRYPT_LOG_N, SCRYPT_R, SCRYPT_P, SCRYPT_DKLEN)
+        .map_err(|e| BttError::crypto(format!("invalid scrypt parameters: {}", e)))?;
+
+    let mut key = [0u8; SCRYPT_DKLEN];
+    scrypt(password.as_bytes(), &salt, &params, &mut key)
+        .map_err(|e| BttError::crypto(format!("scrypt key derivation failed: {}", e)))?;
+
+    // Generate nonce
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = xsalsa20poly1305::Nonce::from(nonce_bytes);
+
+    // Encrypt
+    let cipher = XSalsa20Poly1305::new(xsalsa20poly1305::Key::from_slice(&key));
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|e| BttError::crypto(format!("encryption failed: {}", e)))?;
+
+    // Format: salt (16) || nonce (24) || ciphertext
+    let mut output = Vec::with_capacity(salt.len() + NONCE_LEN + ciphertext.len());
+    output.extend_from_slice(&salt);
+    output.extend_from_slice(&nonce_bytes);
+    output.extend_from_slice(&ciphertext);
+
+    key.zeroize();
+
+    Ok(output)
+}
+
+/// Decrypt key data encrypted with encrypt_key_data.
+fn decrypt_key_data(encrypted: &[u8], password: &str) -> Result<Vec<u8>, BttError> {
+    use scrypt::scrypt;
+    use xsalsa20poly1305::aead::Aead;
+    use xsalsa20poly1305::{KeyInit, XSalsa20Poly1305};
+
+    let min_len = 16 + NONCE_LEN + 16; // salt + nonce + poly1305 tag
+    if encrypted.len() < min_len {
+        return Err(BttError::crypto("encrypted data too short"));
+    }
+
+    let salt = &encrypted[..16];
+    let nonce_bytes = &encrypted[16..16 + NONCE_LEN];
+    let ciphertext = &encrypted[16 + NONCE_LEN..];
+
+    let params = scrypt::Params::new(SCRYPT_LOG_N, SCRYPT_R, SCRYPT_P, SCRYPT_DKLEN)
+        .map_err(|e| BttError::crypto(format!("invalid scrypt parameters: {}", e)))?;
+
+    let mut key = [0u8; SCRYPT_DKLEN];
+    scrypt(password.as_bytes(), salt, &params, &mut key)
+        .map_err(|e| BttError::crypto(format!("scrypt key derivation failed: {}", e)))?;
+
+    let nonce = xsalsa20poly1305::Nonce::from_slice(nonce_bytes);
+    let cipher = XSalsa20Poly1305::new(xsalsa20poly1305::Key::from_slice(&key));
+
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| BttError::crypto("decryption failed — wrong password or corrupted file"))?;
+
+    key.zeroize();
+
+    Ok(plaintext)
+}
+
+/// Write a file and set permissions to 0600 on unix.
+fn write_secure_file(path: &PathBuf, data: &[u8]) -> Result<(), BttError> {
+    fs::write(path, data)
+        .map_err(|e| BttError::io(format!("failed to write {}: {}", path.display(), e)))?;
+
+    #[cfg(unix)]
+    {
+        let perms = std::fs::Permissions::from_mode(0o600);
+        fs::set_permissions(path, perms)
+            .map_err(|e| BttError::io(format!("failed to set permissions on {}: {}", path.display(), e)))?;
+    }
+
+    Ok(())
+}
+
+/// Load and decrypt a coldkey from a wallet directory.
+fn load_coldkey(wallet_dir: &std::path::Path, password: &str) -> Result<Pair, BttError> {
+    let coldkey_path = wallet_dir.join("coldkey");
+    if !coldkey_path.exists() {
+        return Err(BttError::wallet_not_found("coldkey file not found"));
+    }
+
+    let encrypted = fs::read(&coldkey_path)
+        .map_err(|e| BttError::io(format!("failed to read coldkey: {}", e)))?;
+
+    let decrypted = decrypt_key_data(&encrypted, password)?;
+    let json_str = String::from_utf8(decrypted)
+        .map_err(|_| BttError::crypto("decrypted coldkey is not valid UTF-8"))?;
+
+    pair_from_key_json(&json_str)
+}
+
+/// Load a hotkey (unencrypted) from a wallet directory.
+fn load_hotkey(wallet_dir: &std::path::Path, hotkey_name: &str) -> Result<Pair, BttError> {
+    let hotkey_path = wallet_dir.join("hotkeys").join(hotkey_name);
+    if !hotkey_path.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "hotkey '{}' not found",
+            hotkey_name
+        )));
+    }
+
+    let json_str = fs::read_to_string(&hotkey_path)
+        .map_err(|e| BttError::io(format!("failed to read hotkey: {}", e)))?;
+
+    pair_from_key_json(&json_str)
+}
+
+/// Recover a Pair from a btcli-format key JSON string.
+/// Tries secretPhrase first (mnemonic), then secretSeed.
+fn pair_from_key_json(json_str: &str) -> Result<Pair, BttError> {
+    let v: serde_json::Value = serde_json::from_str(json_str)
+        .map_err(|e| BttError::parse(format!("invalid key JSON: {}", e)))?;
+
+    // Try mnemonic first
+    if let Some(phrase) = v.get("secretPhrase").and_then(|v| v.as_str()) {
+        if !phrase.is_empty() {
+            let (pair, _seed) = Pair::from_phrase(phrase, None).map_err(|e| {
+                BttError::crypto(format!("failed to recover from mnemonic: {:?}", e))
+            })?;
+            return Ok(pair);
+        }
+    }
+
+    // Fall back to seed
+    if let Some(seed_str) = v.get("secretSeed").and_then(|v| v.as_str()) {
+        if !seed_str.is_empty() {
+            let seed_bytes = parse_hex_bytes(seed_str)?;
+            if seed_bytes.len() != 32 {
+                return Err(BttError::parse("secretSeed must be 32 bytes"));
+            }
+            let mut seed = [0u8; 32];
+            seed.copy_from_slice(&seed_bytes);
+            let pair = Pair::from_seed(&seed);
+            seed.zeroize();
+            return Ok(pair);
+        }
+    }
+
+    Err(BttError::parse(
+        "key file contains neither secretPhrase nor secretSeed",
+    ))
+}
+
+/// Read password from terminal with no echo.
+pub fn read_password(prompt: &str) -> Result<String, BttError> {
+    rpassword::prompt_password_stdout(prompt)
+        .map_err(|e| BttError::io(format!("failed to read password: {}", e)))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sp_core::Pair as TraitPairAlias;
+
+    #[test]
+    fn generate_12_word_keypair() {
+        let (pair, phrase, seed) = generate_keypair(12).expect("12-word generation should work");
+        let words: Vec<&str> = phrase.split_whitespace().collect();
+        assert_eq!(words.len(), 12);
+        assert!(!seed.iter().all(|&b| b == 0), "seed should not be all zeros");
+        let ss58 = pair.public().to_ss58check();
+        assert!(ss58.starts_with('5'), "SS58 address should start with 5");
+    }
+
+    #[test]
+    fn generate_24_word_keypair() {
+        let (pair, phrase, _seed) = generate_keypair(24).expect("24-word generation should work");
+        let words: Vec<&str> = phrase.split_whitespace().collect();
+        assert_eq!(words.len(), 24);
+        let ss58 = pair.public().to_ss58check();
+        assert!(ss58.starts_with('5'), "SS58 address should start with 5");
+    }
+
+    #[test]
+    fn invalid_n_words_rejected() {
+        assert!(validate_n_words(11).is_err());
+        assert!(validate_n_words(12).is_ok());
+        assert!(validate_n_words(24).is_ok());
+        assert!(validate_n_words(25).is_err());
+    }
+
+    #[test]
+    fn mnemonic_recovery_roundtrip() {
+        let (original, phrase, _seed) =
+            generate_keypair(12).expect("generation should work");
+
+        let (recovered, _recovered_phrase, _recovered_seed) =
+            recover_keypair(Some(&phrase), None).expect("recovery should work");
+
+        assert_eq!(
+            original.public(),
+            recovered.public(),
+            "recovered key should match original"
+        );
+    }
+
+    #[test]
+    fn seed_recovery_roundtrip() {
+        let (_pair, _phrase, seed) = generate_keypair(12).expect("generation should work");
+        let seed_hex = format!("0x{}", hex::encode(seed));
+
+        let (recovered, _, recovered_seed) =
+            recover_keypair(None, Some(&seed_hex)).expect("seed recovery should work");
+
+        assert_eq!(seed, recovered_seed, "recovered seed should match");
+        let pair_from_seed = Pair::from_seed(&seed);
+        assert_eq!(
+            pair_from_seed.public(),
+            recovered.public(),
+            "recovered key should match"
+        );
+    }
+
+    #[test]
+    fn sign_verify_roundtrip() {
+        let (pair, _phrase, _seed) = generate_keypair(12).expect("generation should work");
+        let message = b"test message for signing";
+
+        let sig = <Pair as TraitPairAlias>::sign(&pair, message);
+        let valid =
+            <Pair as TraitPairAlias>::verify(&sig, &message[..], &pair.public());
+        assert!(valid, "signature should verify");
+
+        // Wrong message should fail
+        let bad_valid =
+            <Pair as TraitPairAlias>::verify(&sig, b"wrong message", &pair.public());
+        assert!(!bad_valid, "wrong message should not verify");
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let plaintext = b"sensitive key material here";
+        let password = "test-password-123";
+
+        let encrypted = encrypt_key_data(plaintext, password).expect("encryption should work");
+        assert_ne!(&encrypted[..], plaintext, "ciphertext should differ from plaintext");
+
+        let decrypted = decrypt_key_data(&encrypted, password).expect("decryption should work");
+        assert_eq!(&decrypted[..], plaintext, "decrypted should match original");
+    }
+
+    #[test]
+    fn decrypt_wrong_password_fails() {
+        let plaintext = b"sensitive key material";
+        let encrypted = encrypt_key_data(plaintext, "correct").expect("encryption should work");
+        let result = decrypt_key_data(&encrypted, "wrong");
+        assert!(result.is_err(), "wrong password should fail");
+    }
+
+    #[test]
+    fn key_json_format() {
+        let (pair, phrase, seed) = generate_keypair(12).expect("generation should work");
+        let seed_hex = format!("0x{}", hex::encode(seed));
+        let json = build_key_json(&pair, &phrase, &seed_hex);
+        let json_str =
+            serde_json::to_string(&json).expect("should serialize");
+
+        let v: serde_json::Value =
+            serde_json::from_str(&json_str).expect("should parse");
+        assert!(v.get("accountId").is_some());
+        assert!(v.get("publicKey").is_some());
+        assert!(v.get("secretPhrase").is_some());
+        assert!(v.get("secretSeed").is_some());
+        assert!(v.get("ss58Address").is_some());
+
+        // Verify we can recover from the JSON
+        let recovered = pair_from_key_json(&json_str).expect("should recover");
+        assert_eq!(pair.public(), recovered.public());
+    }
+
+    #[test]
+    fn parse_hex_with_prefix() {
+        let bytes = parse_hex_bytes("0xdeadbeef").expect("should parse");
+        assert_eq!(bytes, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn parse_hex_without_prefix() {
+        let bytes = parse_hex_bytes("deadbeef").expect("should parse");
+        assert_eq!(bytes, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn verify_command_valid_signature() {
+        let (pair, _phrase, _seed) = generate_keypair(12).expect("generation should work");
+        let message = "hello world";
+        let sig = <Pair as TraitPairAlias>::sign(&pair, message.as_bytes());
+        let sig_hex = format!("0x{}", hex::encode(sig.0));
+        let ss58 = pair.public().to_ss58check();
+
+        let result = verify(message, &sig_hex, &ss58).expect("verify should work");
+        assert!(result.valid, "valid signature should verify");
+    }
+
+    #[test]
+    fn verify_command_invalid_signature() {
+        let (pair, _phrase, _seed) = generate_keypair(12).expect("generation should work");
+        let ss58 = pair.public().to_ss58check();
+
+        let result =
+            verify("hello", "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", &ss58)
+                .expect("verify should work even with bad sig");
+        assert!(!result.valid, "invalid signature should not verify");
+    }
+
+    #[test]
+    fn create_wallet_roundtrip() {
+        // Use a temp directory to avoid polluting ~/.bittensor
+        let tmp = std::env::temp_dir().join(format!("btt-test-{}", std::process::id()));
+        let wallet_name = "test-wallet";
+        let _wallet_dir = tmp.join(wallet_name);
+
+        // Override HOME for this test
+        let original_home = std::env::var("HOME").ok();
+        let _bittensor_dir = tmp.clone();
+        // We need to set up the path structure: tmp/.bittensor/wallets/test-wallet
+        let wallets_parent = tmp.join(".bittensor").join("wallets");
+        std::fs::create_dir_all(&wallets_parent).expect("create temp dir");
+
+        std::env::set_var("HOME", tmp.to_str().expect("valid path"));
+
+        let password = "test-password";
+        let result = create(wallet_name, "default", 12, password);
+
+        // Restore HOME
+        if let Some(h) = original_home {
+            std::env::set_var("HOME", &h);
+        }
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let result = result.expect("create should work");
+        assert_eq!(result.wallet_name, wallet_name);
+        assert!(result.coldkey_ss58.starts_with('5'));
+        assert!(result.hotkey_ss58.starts_with('5'));
+        let words: Vec<&str> = result.mnemonic.split_whitespace().collect();
+        assert_eq!(words.len(), 12);
+    }
+
+    // -- TAO/RAO conversion tests --
+
+    #[test]
+    fn tao_to_rao_whole_number() {
+        assert_eq!(tao_to_rao(1.0).expect("1 TAO"), 1_000_000_000);
+    }
+
+    #[test]
+    fn tao_to_rao_fractional() {
+        assert_eq!(tao_to_rao(0.5).expect("0.5 TAO"), 500_000_000);
+    }
+
+    #[test]
+    fn tao_to_rao_zero() {
+        assert_eq!(tao_to_rao(0.0).expect("0 TAO"), 0);
+    }
+
+    #[test]
+    fn tao_to_rao_large_amount() {
+        let rao = tao_to_rao(21_000_000.0).expect("21M TAO");
+        assert_eq!(rao, 21_000_000_000_000_000);
+    }
+
+    #[test]
+    fn tao_to_rao_negative_fails() {
+        assert!(tao_to_rao(-1.0).is_err());
+    }
+
+    #[test]
+    fn tao_to_rao_nan_fails() {
+        assert!(tao_to_rao(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn tao_to_rao_infinity_fails() {
+        assert!(tao_to_rao(f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn rao_to_tao_string_whole() {
+        assert_eq!(rao_to_tao_string(1_000_000_000), "1.0");
+    }
+
+    #[test]
+    fn rao_to_tao_string_fractional() {
+        assert_eq!(rao_to_tao_string(1_500_000_000), "1.5");
+    }
+
+    #[test]
+    fn rao_to_tao_string_zero() {
+        assert_eq!(rao_to_tao_string(0), "0.0");
+    }
+
+    #[test]
+    fn rao_to_tao_string_small() {
+        assert_eq!(rao_to_tao_string(1), "0.000000001");
+    }
+
+    #[test]
+    fn rao_to_tao_string_precise() {
+        assert_eq!(rao_to_tao_string(100_500_000_000), "100.5");
+    }
+
+    #[test]
+    fn extract_ss58_from_json_content() {
+        let json = r#"{"ss58Address": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"}"#;
+        let addr = extract_ss58_from_content(json);
+        assert_eq!(
+            addr,
+            Some("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_ss58_from_raw_content() {
+        let raw = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY\n";
+        let addr = extract_ss58_from_content(raw);
+        assert_eq!(
+            addr,
+            Some("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_ss58_from_empty_returns_none() {
+        assert!(extract_ss58_from_content("").is_none());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,12 @@ pub enum ErrorCode {
     WalletNotFound,
     IoError,
     ParseError,
+    CryptoError,
+    InvalidInput,
+    SigningFailed,
+    SubmissionFailed,
+    DecryptionFailed,
+    InvalidAmount,
     Unknown,
 }
 
@@ -62,6 +68,32 @@ impl BttError {
 
     pub fn parse(msg: impl Into<String>) -> Self {
         Self::new(ErrorCode::ParseError, msg)
+    }
+
+    pub fn crypto(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::CryptoError, msg)
+    }
+
+    pub fn invalid_input(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidInput, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn signing_failed(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::SigningFailed, msg)
+    }
+
+    pub fn submission_failed(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::SubmissionFailed, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn decryption_failed(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::DecryptionFailed, msg)
+    }
+
+    pub fn invalid_amount(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidAmount, msg)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod rpc;
 
 use clap::Parser;
 
-use cli::{ChainAction, Cli, Command, WalletAction};
+use cli::{ChainAction, Cli, Command, StakeAction, WalletAction};
 use error::BttError;
 
 #[tokio::main]
@@ -51,7 +51,138 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 let wallets = commands::wallet::list()?;
                 output::print_success(&wallets, pretty, quiet);
             }
+            WalletAction::Create {
+                name,
+                hotkey,
+                n_words,
+            } => {
+                let password = commands::wallet_keys::read_password("Enter password for coldkey: ")?;
+                let result =
+                    commands::wallet_keys::create(&name, &hotkey, n_words, &password)?;
+                // Mnemonic is always shown, even with --quiet
+                output::print_success(&result, pretty, false);
+            }
+            WalletAction::NewColdkey { name, n_words } => {
+                let password = commands::wallet_keys::read_password("Enter password for coldkey: ")?;
+                let result = commands::wallet_keys::new_coldkey(&name, n_words, &password)?;
+                output::print_success(&result, pretty, false);
+            }
+            WalletAction::NewHotkey {
+                name,
+                hotkey,
+                n_words,
+            } => {
+                let result = commands::wallet_keys::new_hotkey(&name, &hotkey, n_words)?;
+                output::print_success(&result, pretty, false);
+            }
+            WalletAction::RegenColdkey {
+                name,
+                mnemonic,
+                seed,
+            } => {
+                let password = commands::wallet_keys::read_password("Enter password for coldkey: ")?;
+                let result = commands::wallet_keys::regen_coldkey(
+                    &name,
+                    mnemonic.as_deref(),
+                    seed.as_deref(),
+                    &password,
+                )?;
+                output::print_success(&result, pretty, quiet);
+            }
+            WalletAction::RegenHotkey {
+                name,
+                hotkey,
+                mnemonic,
+                seed,
+            } => {
+                let result = commands::wallet_keys::regen_hotkey(
+                    &name,
+                    &hotkey,
+                    mnemonic.as_deref(),
+                    seed.as_deref(),
+                )?;
+                output::print_success(&result, pretty, quiet);
+            }
+            WalletAction::Sign {
+                name,
+                hotkey,
+                message,
+                use_hotkey,
+            } => {
+                let password = if use_hotkey {
+                    None
+                } else {
+                    Some(commands::wallet_keys::read_password("Enter password for coldkey: ")?)
+                };
+                let result = commands::wallet_keys::sign(
+                    &name,
+                    &hotkey,
+                    &message,
+                    use_hotkey,
+                    password.as_deref(),
+                )?;
+                output::print_success(&result, pretty, quiet);
+            }
+            WalletAction::Verify {
+                message,
+                signature,
+                ss58,
+            } => {
+                let result = commands::wallet_keys::verify(&message, &signature, &ss58)?;
+                output::print_success(&result, pretty, quiet);
+            }
         },
+        Command::Stake { action } => {
+            let endpoint = rpc::resolve_endpoint(
+                cli.url.as_deref(),
+                cli.network.as_deref(),
+            )?;
+            match action {
+                StakeAction::List { wallet, ss58 } => {
+                    let result = commands::stake::list(
+                        &endpoint,
+                        wallet.as_deref(),
+                        ss58.as_deref(),
+                    )
+                    .await?;
+                    output::print_success(&result, pretty, quiet);
+                }
+                StakeAction::Add {
+                    wallet,
+                    hotkey,
+                    netuid,
+                    amount,
+                } => {
+                    let result = commands::stake::add(
+                        &endpoint,
+                        &wallet,
+                        &hotkey,
+                        netuid,
+                        amount,
+                    )
+                    .await?;
+                    output::print_success(&result, pretty, quiet);
+                }
+                StakeAction::Remove {
+                    wallet,
+                    hotkey,
+                    netuid,
+                    amount,
+                    all,
+                } => {
+                    let result = commands::stake::remove(
+                        &endpoint,
+                        &wallet,
+                        &hotkey,
+                        netuid,
+                        amount,
+                        all,
+                    )
+                    .await?;
+                    output::print_success(&result, pretty, quiet);
+                }
+            }
+        }
         Command::Skill => {
             if !quiet {
                 print!("{}", commands::skill::skill_md());


### PR DESCRIPTION
## Summary

- **`btt stake list`** -- read-only query of all stakes for a coldkey address (via `--wallet` or `--ss58`). Uses `StakingHotkeys` storage to discover hotkeys, then queries `Alpha` triple map for per-subnet stake amounts, with `Stake` double map fallback.
- **`btt stake add`** -- stake TAO from coldkey to hotkey on a specific subnet. Constructs and submits `SubtensorModule::add_stake(hotkey, netuid, amount_rao)` extrinsic signed by the decrypted coldkey.
- **`btt stake remove`** -- unstake TAO. Supports `--amount` or `--all` flag which queries current stake before submitting `SubtensorModule::remove_stake`.
- Adds `wallet_keys` module with coldkey decryption (NaCl/scrypt encrypted or plaintext JSON), TAO/RAO conversion, key generation, signing, and verification.
- Adds CLI definitions for `StakeAction` enum and wires routing in `main.rs`.
- Adds dependencies: `rpassword`, `xsalsa20poly1305`, `scrypt`, `zeroize`, `rand`.

## Key design decisions

- TAO amounts accepted as `f64`, converted to RAO (`u64`, 1 TAO = 1e9 RAO) with validation for NaN/Inf/negative/overflow.
- Coldkey decryption tries plaintext JSON first, then prompts for password and decrypts via scrypt + xsalsa20poly1305 (btcli-compatible format).
- Key material is zeroized after use.
- All extrinsic submissions use `sign_and_submit_then_watch_default` and wait for finalization.

## Test plan

- [x] `cargo build` -- zero errors
- [x] `cargo clippy -- -D warnings` -- zero warnings
- [x] `cargo test` -- 49 tests pass, including:
  - TAO/RAO conversion (whole, fractional, zero, large, negative, NaN, Infinity)
  - RAO-to-TAO string formatting (whole, fractional, zero, small, precise)
  - SS58 address resolution and validation
  - Encrypt/decrypt roundtrip, wrong-password rejection
  - Wallet creation roundtrip, mnemonic/seed recovery
  - Sign/verify roundtrip
- [ ] Manual test against testnet: `btt stake list --ss58 <addr> --network test`
- [ ] Manual test: `btt stake add --wallet <name> --hotkey <ss58> --netuid 1 --amount 0.1 --network test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)