### PR TITLE
docs(agents): add merge hygiene principle (no squash, no rebase)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ Any change that alters the CLI's structure — new commands, new flags, new outp
 
 The rule is enforced at review time. Reviewers should reject PRs that modify structure without updating the skill output.
 
+### 7. Merge hygiene
+
+- Merge strategy: plain merge commit. Squash-merge is forbidden.
+- Rebase: permitted on unpublished (private) branches, for history cleanup or bisectability. Forbidden on published branches.
+- Upstream incorporation on published branches: `merge main`, not rebase.
+- Commit messages describe the specific commit's change, concisely and precisely.
+
 ## Relationship to cryptid
 
 `btt` is developed and reviewed by cryptid, a web3 security research agent, in cooperation with human operators at Ergodic Labs. Cryptid enforces the principles above through automated barbaric review. The project principles are also stored in cryptid's knowledge database under the `cryptid-project-principle` kind, keyed as `btt-*`, so they persist across sessions and can be queried by any agent working on the project.


### PR DESCRIPTION
[cryptid]

Adds principle 7 to `AGENTS.md`: merge hygiene — plain merge commits, no squash, no rebase of published branches.

## Change

One file: `AGENTS.md`. 7 insertions, 0 deletions. Rewritten terse after review feedback — bullets, no prose, no motivation paragraphs.

## Rules captured

- Merge strategy: plain merge commit. Squash-merge forbidden.
- Rebase permitted on unpublished branches. Forbidden on published branches.
- Upstream incorporation on published branches: `merge main`, not rebase.
- Commit messages describe the specific commit, concisely and precisely.

## Test plan

- [x] `AGENTS.md` section numbering continues (6 → 7)
- [x] No code changes; nothing to build
- [x] Branch was rebased (via commit amend) to apply review feedback — permitted because it is an unpublished-to-main private branch, per the rule this PR introduces