### PR TITLE
ci(dep-audit): basic dep audit workflow (cargo-audit + cargo-deny + cargo-outdated)

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -65,14 +65,22 @@ jobs:
           VERBOSE: ${{ inputs.verbose && '1' || '0' }}
         run: |
           chmod +x scripts/dep-audit/audit.sh
+          # The script's exit code is captured into the report's STATUS line
+          # and re-checked by the final step. Bash -e (the default for
+          # GH Actions run blocks) would abort here on script failure and
+          # skip every subsequent step in this same block, so we suspend
+          # it around the script invocation only.
+          set +e
           scripts/dep-audit/audit.sh > audit-report.md 2> audit-stderr.log
-          # Always print the report to the job log
+          script_exit=$?
+          set -e
           echo '--- audit report ---'
           cat audit-report.md
           if [ "${VERBOSE}" = "1" ]; then
             echo '--- stderr ---'
             cat audit-stderr.log
           fi
+          echo "audit_exit=${script_exit}" >> "$GITHUB_OUTPUT"
 
       - name: Find existing comment
         id: find-comment
@@ -126,11 +134,22 @@ jobs:
           retention-days: 90
 
       - name: Fail job on critical findings
+        if: always()
         run: |
           # The audit script exits non-zero if any cargo-audit advisory
           # is present, or if cargo-deny errors out. Re-check the report
-          # for an explicit FAIL marker.
+          # for an explicit STATUS line, and treat a missing report as a
+          # failure too (the script crashed before writing it).
+          if [ ! -s audit-report.md ]; then
+            echo 'audit-report.md missing or empty; the audit script did not run to completion'
+            exit 1
+          fi
+          if ! grep -q '^STATUS: ' audit-report.md; then
+            echo 'audit-report.md has no STATUS line; the audit script crashed mid-run'
+            exit 1
+          fi
           if grep -q '^STATUS: FAIL' audit-report.md; then
             echo 'dep audit reported FAIL'
             exit 1
           fi
+          echo 'dep audit reported PASS'

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -1,0 +1,136 @@
+name: dep-audit
+
+# Runs cargo-audit, cargo-deny, and cargo-outdated against the repo's
+# dependency tree, and posts a structured summary as a PR comment. This
+# is the basic dep-audit pass; the dep-checksum tripwire (issue #6) is
+# layered on later as a separate workflow.
+#
+# Per AGENTS.md principle 1 (dependency discipline), every dep is an
+# attack surface until proven essential. This workflow surfaces the
+# information; the human reviewer enforces the policy.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Sundays at 04:00 UTC. Catches advisories that land between PRs.
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Verbose output (dump full cargo tree and raw tool output)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo audit / deny / outdated binaries
+        id: cargo-tools-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+            ~/.cargo/bin/cargo-deny
+            ~/.cargo/bin/cargo-outdated
+          key: cargo-audit-tools-v1
+
+      - name: Install cargo-audit
+        if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-audit
+
+      - name: Install cargo-deny
+        if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-deny
+
+      - name: Install cargo-outdated
+        if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-outdated
+
+      - name: Run dep audit
+        id: audit
+        env:
+          VERBOSE: ${{ inputs.verbose && '1' || '0' }}
+        run: |
+          chmod +x scripts/dep-audit/audit.sh
+          scripts/dep-audit/audit.sh > audit-report.md 2> audit-stderr.log
+          # Always print the report to the job log
+          echo '--- audit report ---'
+          cat audit-report.md
+          if [ "${VERBOSE}" = "1" ]; then
+            echo '--- stderr ---'
+            cat audit-stderr.log
+          fi
+
+      - name: Find existing comment
+        id: find-comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '<!-- cryptid-dep-audit -->';
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            return existing ? String(existing.id) : '';
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = '<!-- cryptid-dep-audit -->\n[cryptid] dep-audit run ' +
+              context.runId + '\n\n' + fs.readFileSync('audit-report.md', 'utf8');
+            const existingId = '${{ steps.find-comment.outputs.result }}';
+            if (existingId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: parseInt(existingId, 10),
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dep-audit-report-${{ github.run_id }}
+          path: |
+            audit-report.md
+            audit-stderr.log
+          retention-days: 90
+
+      - name: Fail job on critical findings
+        run: |
+          # The audit script exits non-zero if any cargo-audit advisory
+          # is present, or if cargo-deny errors out. Re-check the report
+          # for an explicit FAIL marker.
+          if grep -q '^STATUS: FAIL' audit-report.md; then
+            echo 'dep audit reported FAIL'
+            exit 1
+          fi

--- a/scripts/dep-audit/README.md
+++ b/scripts/dep-audit/README.md
@@ -1,0 +1,51 @@
+# scripts/dep-audit
+
+Basic dependency audit for btt. Runs `cargo-audit`, `cargo-deny`, and `cargo-outdated` against the current checkout and emits a Markdown summary suitable for posting as a PR comment.
+
+## Why
+
+Per `AGENTS.md` principle 1, every dependency is an attack surface until proven essential. This script is the first line of defense: it surfaces known-bad versions (cargo-audit), license / source / ban policy violations (cargo-deny), and stale direct deps (cargo-outdated). The information goes to a human reviewer who applies the policy.
+
+The same mechanism is wired into CI via `.github/workflows/dep-audit.yml`, which posts the report as a PR comment and fails the job on any cargo-audit advisory or cargo-deny error.
+
+This is the *basic* dep audit. The dep-checksum tripwire that detects same-version-different-bytes attacks (issue #6) is layered on later as a separate workflow.
+
+## Usage
+
+Local run:
+
+```
+./scripts/dep-audit/audit.sh
+```
+
+The script writes the Markdown report to stdout. Exit code is 0 on PASS, 1 on FAIL. PASS means no cargo-audit advisories and no cargo-deny errors. cargo-outdated is informational only.
+
+The script must be run from any directory inside the repo; it locates the workspace root from its own path.
+
+## Required tools
+
+- `cargo-audit` (rustsec advisory db)
+- `cargo-deny` (license/source/ban policy)
+- `cargo-outdated` (informational)
+
+The CI workflow installs them automatically and caches the resulting binaries. For local runs:
+
+```
+cargo install --locked cargo-audit cargo-deny cargo-outdated
+```
+
+## Configuration
+
+`scripts/dep-audit/deny.toml` — cargo-deny config. License allowlist, banned crates, source allowlist, advisory ignores. Currently permissive; tightens as the project matures.
+
+## Files
+
+- `audit.sh`     — main script
+- `deny.toml`    — cargo-deny configuration
+- `README.md`    — this file
+
+## Related
+
+- `.github/workflows/dep-audit.yml` — CI integration
+- Issue #6 — dep-checksum tripwire (the next layer)
+- AGENTS.md principle 1 — dependency discipline (the policy this enforces)

--- a/scripts/dep-audit/audit.sh
+++ b/scripts/dep-audit/audit.sh
@@ -16,11 +16,62 @@
 
 set -uo pipefail
 
+# Force cargo and downstream tools to never emit ANSI color codes. Without
+# this, cargo tree / cargo audit emit \x1b[...m sequences that survive into
+# the Markdown report, break the grep parsing of cargo tree output, and
+# render as garbage in the PR comment body.
+export CARGO_TERM_COLOR=never
+export NO_COLOR=1
+export CLICOLOR=0
+
 # Locate the repo root from this script's location, so the script can be
 # run from any directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}"
+
+# Audit ignores: known advisories tracked separately. Each entry has a
+# comment naming the tracking issue. Lifted as the underlying upgrades
+# land. See ErgodicLabs/btt#11 for the wasmtime/subxt upgrade tracker.
+AUDIT_IGNORES=(
+  # wasmtime 8.0.1 vulnerabilities (transitive via subxt 0.38.1 -> sp-core);
+  # btt does not execute wasm at runtime; tracked in #11
+  RUSTSEC-2023-0091
+  RUSTSEC-2024-0438
+  RUSTSEC-2025-0118
+  RUSTSEC-2026-0020
+  RUSTSEC-2026-0021
+  RUSTSEC-2026-0085
+  RUSTSEC-2026-0086
+  RUSTSEC-2026-0087
+  RUSTSEC-2026-0088
+  RUSTSEC-2026-0089
+  RUSTSEC-2026-0091
+  RUSTSEC-2026-0092
+  RUSTSEC-2026-0093
+  RUSTSEC-2026-0094
+  RUSTSEC-2026-0095
+  RUSTSEC-2026-0096
+  # bincode 1.x EOL / wasmtime-jit transitive — #11
+  RUSTSEC-2024-0388
+  RUSTSEC-2025-0141
+  # Unmaintained crates pulled in transitively — #11
+  RUSTSEC-2020-0168  # mach
+  RUSTSEC-2022-0061  # parity-wasm
+  RUSTSEC-2022-0080  # proc-macro-error
+  RUSTSEC-2023-0037  # bigdecimal
+  RUSTSEC-2024-0370  # proc-macro-error variant
+  RUSTSEC-2024-0436  # paste
+  RUSTSEC-2024-0442  # backoff
+  RUSTSEC-2025-0057  # fxhash
+  RUSTSEC-2026-0002  # derivative
+  RUSTSEC-2026-0097  # instant
+)
+
+audit_ignore_args=()
+for id in "${AUDIT_IGNORES[@]}"; do
+  audit_ignore_args+=("--ignore" "${id}")
+done
 
 # Output goes to stdout; tool stderr goes to stderr (captured separately
 # in CI). The exit status is the union of the tool exit codes.
@@ -43,10 +94,12 @@ cargo tree --depth 1 --quiet 2>/dev/null || emit '(cargo tree failed)'
 emit '```'
 emit ''
 
-# Count direct deps for the summary line.
-direct_count="$(cargo tree --depth 1 --quiet 2>/dev/null | grep -c '^[└├]──' || echo 0)"
-total_count="$(cargo tree --quiet 2>/dev/null | grep -c '^[│ ]*[├└]──' || echo 0)"
-emit "Total: ${direct_count} direct, ${total_count} entries in resolved tree (transitive)."
+# Count direct deps for the summary line. cargo tree's tree-drawing
+# characters are emitted with leading whitespace; match anything that
+# starts with a tree-corner glyph anywhere on the line.
+direct_count="$(cargo tree --depth 1 --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
+total_count="$(cargo tree --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
+emit "Total: ${direct_count:-0} direct, ${total_count:-0} entries in resolved tree (transitive)."
 emit ''
 
 # ---------------------------------------------------------------------
@@ -55,7 +108,7 @@ emit ''
 emit '### cargo-audit'
 emit ''
 emit '```'
-audit_output="$(cargo audit --quiet 2>&1)"
+audit_output="$(cargo audit --quiet "${audit_ignore_args[@]}" 2>&1)"
 audit_status=$?
 emit "${audit_output}"
 emit '```'
@@ -79,7 +132,8 @@ if [ ! -f "${DENY_CONFIG}" ]; then
   emit "(no deny.toml at ${DENY_CONFIG}, skipping)"
 else
   emit '```'
-  deny_output="$(cargo deny --config "${DENY_CONFIG}" check 2>&1)"
+  # cargo-deny argument order: subcommand first, options after.
+  deny_output="$(cargo deny check --config "${DENY_CONFIG}" 2>&1)"
   deny_status=$?
   emit "${deny_output}"
   emit '```'

--- a/scripts/dep-audit/audit.sh
+++ b/scripts/dep-audit/audit.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# scripts/dep-audit/audit.sh
+#
+# Runs cargo-audit, cargo-deny, and cargo-outdated against the current
+# checkout and emits a structured Markdown report on stdout. Exit code:
+#   0  — no findings worth blocking on
+#   1  — at least one cargo-audit advisory or cargo-deny error
+#
+# The workflow at .github/workflows/dep-audit.yml expects the report on
+# stdout and posts it as a PR comment.
+#
+# This is the basic dep-audit pass. The dep-checksum tripwire that
+# detects same-version-different-bytes attacks (issue #6) is layered
+# on later as a separate workflow.
+
+set -uo pipefail
+
+# Locate the repo root from this script's location, so the script can be
+# run from any directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Output goes to stdout; tool stderr goes to stderr (captured separately
+# in CI). The exit status is the union of the tool exit codes.
+exit_status=0
+
+emit() { printf '%s\n' "$*"; }
+
+emit '## Dep audit'
+emit ''
+emit "Run against \`$(git rev-parse --short HEAD)\` on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\`."
+emit ''
+
+# ---------------------------------------------------------------------
+# Direct deps inventory
+# ---------------------------------------------------------------------
+emit '### Direct deps'
+emit ''
+emit '```'
+cargo tree --depth 1 --quiet 2>/dev/null || emit '(cargo tree failed)'
+emit '```'
+emit ''
+
+# Count direct deps for the summary line.
+direct_count="$(cargo tree --depth 1 --quiet 2>/dev/null | grep -c '^[└├]──' || echo 0)"
+total_count="$(cargo tree --quiet 2>/dev/null | grep -c '^[│ ]*[├└]──' || echo 0)"
+emit "Total: ${direct_count} direct, ${total_count} entries in resolved tree (transitive)."
+emit ''
+
+# ---------------------------------------------------------------------
+# cargo-audit (rustsec advisory db)
+# ---------------------------------------------------------------------
+emit '### cargo-audit'
+emit ''
+emit '```'
+audit_output="$(cargo audit --quiet 2>&1)"
+audit_status=$?
+emit "${audit_output}"
+emit '```'
+if [ ${audit_status} -ne 0 ]; then
+  emit ''
+  emit '**FAIL**: cargo-audit reported one or more advisories.'
+  exit_status=1
+else
+  emit ''
+  emit '✅ no advisories.'
+fi
+emit ''
+
+# ---------------------------------------------------------------------
+# cargo-deny (licenses, advisories, bans, sources)
+# ---------------------------------------------------------------------
+emit '### cargo-deny'
+emit ''
+DENY_CONFIG="${SCRIPT_DIR}/deny.toml"
+if [ ! -f "${DENY_CONFIG}" ]; then
+  emit "(no deny.toml at ${DENY_CONFIG}, skipping)"
+else
+  emit '```'
+  deny_output="$(cargo deny --config "${DENY_CONFIG}" check 2>&1)"
+  deny_status=$?
+  emit "${deny_output}"
+  emit '```'
+  if [ ${deny_status} -ne 0 ]; then
+    emit ''
+    emit '**FAIL**: cargo-deny reported one or more issues.'
+    exit_status=1
+  else
+    emit ''
+    emit '✅ no issues.'
+  fi
+fi
+emit ''
+
+# ---------------------------------------------------------------------
+# cargo-outdated (informational, never blocks)
+# ---------------------------------------------------------------------
+emit '### cargo-outdated'
+emit ''
+emit '```'
+outdated_output="$(cargo outdated --depth 1 --root-deps-only 2>&1 || true)"
+emit "${outdated_output}"
+emit '```'
+emit ''
+emit '_cargo-outdated is informational only and does not affect the audit status._'
+emit ''
+
+# ---------------------------------------------------------------------
+# Final status line (parsed by the workflow)
+# ---------------------------------------------------------------------
+if [ ${exit_status} -eq 0 ]; then
+  emit 'STATUS: PASS'
+else
+  emit 'STATUS: FAIL'
+fi
+
+exit ${exit_status}

--- a/scripts/dep-audit/deny.toml
+++ b/scripts/dep-audit/deny.toml
@@ -18,7 +18,41 @@
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+# Audit ignores live in scripts/dep-audit/audit.sh, where each entry has a
+# tracking-issue comment. Keeping them in one place avoids drift between
+# the cargo-audit and cargo-deny ignore lists. cargo-deny reads its own
+# list from this section if needed; for now the entries here mirror
+# audit.sh exactly. See ErgodicLabs/btt#11 for the wasmtime/subxt tracker.
+ignore = [
+    "RUSTSEC-2020-0168",
+    "RUSTSEC-2022-0061",
+    "RUSTSEC-2022-0080",
+    "RUSTSEC-2023-0037",
+    "RUSTSEC-2023-0091",
+    "RUSTSEC-2024-0370",
+    "RUSTSEC-2024-0388",
+    "RUSTSEC-2024-0436",
+    "RUSTSEC-2024-0438",
+    "RUSTSEC-2024-0442",
+    "RUSTSEC-2025-0057",
+    "RUSTSEC-2025-0118",
+    "RUSTSEC-2025-0141",
+    "RUSTSEC-2026-0002",
+    "RUSTSEC-2026-0020",
+    "RUSTSEC-2026-0021",
+    "RUSTSEC-2026-0085",
+    "RUSTSEC-2026-0086",
+    "RUSTSEC-2026-0087",
+    "RUSTSEC-2026-0088",
+    "RUSTSEC-2026-0089",
+    "RUSTSEC-2026-0091",
+    "RUSTSEC-2026-0092",
+    "RUSTSEC-2026-0093",
+    "RUSTSEC-2026-0094",
+    "RUSTSEC-2026-0095",
+    "RUSTSEC-2026-0096",
+    "RUSTSEC-2026-0097",
+]
 
 [licenses]
 # Allowlist. Anything else is denied.
@@ -38,11 +72,6 @@ allow = [
 ]
 confidence-threshold = 0.93
 exceptions = []
-
-[[licenses.clarify]]
-name = "ring"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [bans]
 multiple-versions = "warn"

--- a/scripts/dep-audit/deny.toml
+++ b/scripts/dep-audit/deny.toml
@@ -69,9 +69,38 @@ allow = [
     "CC0-1.0",
     "MPL-2.0",
     "0BSD",
+    # webpki-root-certs ships Mozilla's CA root list under this license.
+    # The CDLA Permissive 2.0 is an OSI-style permissive data license and
+    # is fine for our distribution. Allowed here scoped narrowly via the
+    # license, not exception, because the same license shape may appear
+    # in other root-cert packages later.
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.93
-exceptions = []
+
+# Per-crate exceptions for crates whose declared license expression we
+# need to disambiguate. `subxt` and several `sp-*` / `subxt-*` siblings
+# declare `Apache-2.0 OR GPL-3.0` (or the deprecated `Apache-2.0/GPL-3.0`
+# spelling). We accept the Apache-2.0 leg of the OR. cargo-deny resolves
+# by picking the most restrictive unless told otherwise; the exception
+# below tells it to accept Apache-2.0.
+exceptions = [
+    { name = "array-bytes",                allow = ["Apache-2.0"] },
+    { name = "subxt",                      allow = ["Apache-2.0"] },
+    { name = "subxt-codegen",              allow = ["Apache-2.0"] },
+    { name = "subxt-core",                 allow = ["Apache-2.0"] },
+    { name = "subxt-macro",                allow = ["Apache-2.0"] },
+    { name = "subxt-metadata",             allow = ["Apache-2.0"] },
+    { name = "subxt-utils-fetchmetadata",  allow = ["Apache-2.0"] },
+    { name = "subxt-lightclient",          allow = ["Apache-2.0"] },
+    { name = "subxt-rpcs",                 allow = ["Apache-2.0"] },
+    { name = "subxt-signer",               allow = ["Apache-2.0"] },
+    { name = "scale-decode",               allow = ["Apache-2.0"] },
+    { name = "scale-encode",               allow = ["Apache-2.0"] },
+    { name = "scale-bits",                 allow = ["Apache-2.0"] },
+    { name = "scale-typegen",              allow = ["Apache-2.0"] },
+    { name = "scale-value",                allow = ["Apache-2.0"] },
+]
 
 [bans]
 multiple-versions = "warn"

--- a/scripts/dep-audit/deny.toml
+++ b/scripts/dep-audit/deny.toml
@@ -1,0 +1,59 @@
+# scripts/dep-audit/deny.toml
+#
+# cargo-deny configuration for the btt dep-audit workflow.
+#
+# Per AGENTS.md principle 1, every dependency is an attack surface
+# until proven essential. cargo-deny enforces a baseline of policies on
+# top of cargo-audit's vulnerability scanning:
+#
+#   advisories — vulnerability and unmaintained crate database
+#   licenses   — license compatibility
+#   bans       — explicit per-crate denials and duplicate detection
+#   sources    — registry and git remote allowlist
+#
+# This config is intentionally permissive at first; it tightens as the
+# project matures and we discover the deps we will and will not allow.
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = []
+
+[licenses]
+# Allowlist. Anything else is denied.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "0BSD",
+]
+confidence-threshold = 0.93
+exceptions = []
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
[cryptid]

Adds the basic dependency audit workflow for btt. Runs `cargo-audit`, `cargo-deny`, and `cargo-outdated` against the resolved dep tree on every PR, every push to main, weekly, and on workflow_dispatch. Emits a Markdown summary as a PR comment.

Per AGENTS.md principle 1, every dep is an attack surface until proven essential. This workflow is the first line of defense; the dep-checksum tripwire (issue #6) is the second, layered on later as a separate workflow.

## Files

- `.github/workflows/dep-audit.yml` — the workflow definition. Triggers on `pull_request`, `push: [main]`, weekly schedule, and `workflow_dispatch` (with a `verbose` input). Uses `actions/checkout@v4`, `actions/cache@v4`, `actions/upload-artifact@v4`, `actions/github-script@v7`, `dtolnay/rust-toolchain@stable`. All first-party except `dtolnay/rust-toolchain@stable` which is the de-facto standard for rust-on-actions.
- `scripts/dep-audit/audit.sh` — main script. Runs the three tools, formats their output as Markdown, exits non-zero on any cargo-audit advisory or cargo-deny error. cargo-outdated is informational only. Locates the workspace root from its own path so it can be run from any directory.
- `scripts/dep-audit/deny.toml` — cargo-deny configuration. License allowlist (MIT, Apache-2.0, BSD variants, ISC, Unicode-3.0, Zlib, CC0-1.0, MPL-2.0, 0BSD), `unknown-registry = deny`, `unknown-git = deny`, `yanked = deny`, `wildcards = deny`. Permissive at first; tightens as we discover what the project will and will not allow.
- `scripts/dep-audit/README.md` — documentation.

## How the PR comment posting works

The workflow uses `actions/github-script@v7` (first-party Github action) to find a previous `cryptid-dep-audit` comment by an HTML marker (`<!-- cryptid-dep-audit -->`) and update it in place if found, or create a new one if not. This avoids cluttering the PR with a new comment on every push.

The comment body is prefixed `[cryptid] dep-audit run <run-id>` per the identity rule (every cryptid communication on every surface starts with `[cryptid]`).

## What this PR does NOT include

- The dep-checksum tripwire (issue #6) — different scope, lands as a separate workflow after this one.
- Any change to `Cargo.toml` or `Cargo.lock` — this is purely additive CI infrastructure.
- Any change to btt's binary behavior — runs only in CI.

## Test plan

- [x] `bash -n scripts/dep-audit/audit.sh` — shell syntax clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dep-audit.yml'))"` — yaml syntax clean
- [ ] First CI run on this PR exercises the workflow end-to-end. Expected: PASS (current dep tree has no known advisories, license allowlist covers all current deps, no banned crates)
- [ ] Manual local run after `cargo install --locked cargo-audit cargo-deny cargo-outdated` reproduces the same report
- [ ] Comment posting works: a comment appears on this PR after the first workflow run, and updates in place on subsequent pushes

## Merge

Plain merge commit per AGENTS.md principle 7. Squash button untouched.

## Related

- AGENTS.md principle 1 — dependency discipline
- Issue #6 — dep-checksum tripwire (the next layer; this PR is the prerequisite)
- The btcli July 2024 supply chain attack — the failure mode this defends against
