### PR TITLE
ci(dep-audit): parallelize via matrix and fix cache key

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -1,13 +1,17 @@
 name: dep-audit
 
 # Runs cargo-audit, cargo-deny, and cargo-outdated against the repo's
-# dependency tree, and posts a structured summary as a PR comment. This
-# is the basic dep-audit pass; the dep-checksum tripwire (issue #6) is
-# layered on later as a separate workflow.
+# dependency tree in parallel matrix jobs, then combines the three
+# reports into a single structured summary posted as a PR comment.
 #
 # Per AGENTS.md principle 1 (dependency discipline), every dep is an
 # attack surface until proven essential. This workflow surfaces the
 # information; the human reviewer enforces the policy.
+#
+# Tool versions are pinned in scripts/dep-audit/tool-versions.txt so
+# the cache key invalidates whenever we bump a tool, and the install
+# step reads the same file so the binary in the cache matches the
+# version we asked for.
 
 on:
   pull_request:
@@ -30,6 +34,10 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [cargo-audit, cargo-deny, cargo-outdated]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,50 +45,128 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo audit / deny / outdated binaries
-        id: cargo-tools-cache
+      - name: Cache ${{ matrix.tool }} binary
+        id: tool-cache
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/bin/cargo-audit
-            ~/.cargo/bin/cargo-deny
-            ~/.cargo/bin/cargo-outdated
-          key: cargo-audit-tools-v1
+          path: ~/.cargo/bin/${{ matrix.tool }}
+          key: cargo-${{ matrix.tool }}-${{ runner.os }}-${{ hashFiles('scripts/dep-audit/tool-versions.txt') }}
 
-      - name: Install cargo-audit
-        if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-audit
+      - name: Install ${{ matrix.tool }}
+        if: steps.tool-cache.outputs.cache-hit != 'true'
+        run: |
+          # Read the pinned version from tool-versions.txt. The file is
+          # a simple "<tool> = <version>" list so the same source of
+          # truth feeds the cache key hash and the install command.
+          version="$(awk -v t='${{ matrix.tool }}' '$1 == t { print $3; exit }' scripts/dep-audit/tool-versions.txt)"
+          if [ -z "${version}" ]; then
+            echo "no pinned version for ${{ matrix.tool }} in scripts/dep-audit/tool-versions.txt" >&2
+            exit 1
+          fi
+          echo "installing ${{ matrix.tool }}@${version}"
+          cargo install --locked --version "${version}" '${{ matrix.tool }}'
 
-      - name: Install cargo-deny
-        if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-deny
-
-      - name: Install cargo-outdated
-        if: steps.cargo-tools-cache.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-outdated
-
-      - name: Run dep audit
-        id: audit
+      - name: Run ${{ matrix.tool }}
+        id: run
         env:
           VERBOSE: ${{ inputs.verbose && '1' || '0' }}
         run: |
-          chmod +x scripts/dep-audit/audit.sh
-          # The script's exit code is captured into the report's STATUS line
-          # and re-checked by the final step. Bash -e (the default for
-          # GH Actions run blocks) would abort here on script failure and
-          # skip every subsequent step in this same block, so we suspend
-          # it around the script invocation only.
+          chmod +x scripts/dep-audit/run-one.sh
+          # Suspend bash -e around the script so its exit status flows
+          # through to the artifact instead of aborting the job. The
+          # combine job re-derives pass/fail from the per-tool status
+          # files in the downloaded artifacts.
           set +e
-          scripts/dep-audit/audit.sh > audit-report.md 2> audit-stderr.log
-          script_exit=$?
+          scripts/dep-audit/run-one.sh '${{ matrix.tool }}' \
+            > 'report-${{ matrix.tool }}.md' \
+            2> 'stderr-${{ matrix.tool }}.log'
+          tool_exit=$?
           set -e
-          echo '--- audit report ---'
-          cat audit-report.md
+          printf '%s\n' "${tool_exit}" > 'status-${{ matrix.tool }}.txt'
+          echo '--- report ---'
+          cat 'report-${{ matrix.tool }}.md'
           if [ "${VERBOSE}" = "1" ]; then
             echo '--- stderr ---'
-            cat audit-stderr.log
+            cat 'stderr-${{ matrix.tool }}.log'
           fi
-          echo "audit_exit=${script_exit}" >> "$GITHUB_OUTPUT"
+          echo "tool_exit=${tool_exit}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload ${{ matrix.tool }} artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dep-audit-${{ matrix.tool }}-${{ github.run_id }}
+          path: |
+            report-${{ matrix.tool }}.md
+            stderr-${{ matrix.tool }}.log
+            status-${{ matrix.tool }}.txt
+          retention-days: 90
+
+  combine:
+    runs-on: ubuntu-latest
+    needs: [audit]
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all matrix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dep-audit-artifacts
+          pattern: dep-audit-*-${{ github.run_id }}
+
+      - name: Combine reports
+        id: combine
+        run: |
+          set -uo pipefail
+          artifacts_root='dep-audit-artifacts'
+          combined='combined-report.md'
+
+          {
+            printf '## Dep audit\n\n'
+            printf 'Run against `%s` on `%s`.\n\n' \
+              "$(git rev-parse --short HEAD)" \
+              "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          } > "${combined}"
+
+          overall_exit=0
+          # Fixed order so the combined report is deterministic regardless
+          # of matrix scheduling.
+          for tool in cargo-audit cargo-deny cargo-outdated; do
+            artifact_dir="${artifacts_root}/dep-audit-${tool}-${{ github.run_id }}"
+            report="${artifact_dir}/report-${tool}.md"
+            status_file="${artifact_dir}/status-${tool}.txt"
+
+            if [ ! -f "${report}" ]; then
+              printf '### %s\n\n' "${tool}" >> "${combined}"
+              printf '(report missing — matrix job crashed before writing output)\n\n' >> "${combined}"
+              overall_exit=1
+              continue
+            fi
+
+            cat "${report}" >> "${combined}"
+            printf '\n' >> "${combined}"
+
+            if [ -f "${status_file}" ]; then
+              tool_exit="$(cat "${status_file}")"
+            else
+              tool_exit=1
+            fi
+            if [ "${tool_exit}" != "0" ]; then
+              overall_exit=1
+            fi
+          done
+
+          if [ "${overall_exit}" = "0" ]; then
+            printf 'STATUS: PASS\n' >> "${combined}"
+          else
+            printf 'STATUS: FAIL\n' >> "${combined}"
+          fi
+
+          echo '--- combined report ---'
+          cat "${combined}"
+          echo "overall_exit=${overall_exit}" >> "$GITHUB_OUTPUT"
 
       - name: Find existing comment
         id: find-comment
@@ -105,7 +191,7 @@ jobs:
           script: |
             const fs = require('fs');
             const body = '<!-- cryptid-dep-audit -->\n[cryptid] dep-audit run ' +
-              context.runId + '\n\n' + fs.readFileSync('audit-report.md', 'utf8');
+              context.runId + '\n\n' + fs.readFileSync('combined-report.md', 'utf8');
             const existingId = '${{ steps.find-comment.outputs.result }}';
             if (existingId) {
               await github.rest.issues.updateComment({
@@ -123,33 +209,19 @@ jobs:
               });
             }
 
-      - name: Upload audit artifact
+      - name: Upload combined report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: dep-audit-report-${{ github.run_id }}
-          path: |
-            audit-report.md
-            audit-stderr.log
+          name: dep-audit-combined-${{ github.run_id }}
+          path: combined-report.md
           retention-days: 90
 
-      - name: Fail job on critical findings
-        if: always()
+      - name: Fail combine job on any tool failure
         run: |
-          # The audit script exits non-zero if any cargo-audit advisory
-          # is present, or if cargo-deny errors out. Re-check the report
-          # for an explicit STATUS line, and treat a missing report as a
-          # failure too (the script crashed before writing it).
-          if [ ! -s audit-report.md ]; then
-            echo 'audit-report.md missing or empty; the audit script did not run to completion'
-            exit 1
-          fi
-          if ! grep -q '^STATUS: ' audit-report.md; then
-            echo 'audit-report.md has no STATUS line; the audit script crashed mid-run'
-            exit 1
-          fi
-          if grep -q '^STATUS: FAIL' audit-report.md; then
-            echo 'dep audit reported FAIL'
+          overall_exit='${{ steps.combine.outputs.overall_exit }}'
+          if [ "${overall_exit}" != "0" ]; then
+            echo 'dep audit reported FAIL (at least one matrix job blocked)'
             exit 1
           fi
           echo 'dep audit reported PASS'

--- a/scripts/dep-audit/audit.sh
+++ b/scripts/dep-audit/audit.sh
@@ -2,168 +2,55 @@
 #
 # scripts/dep-audit/audit.sh
 #
-# Runs cargo-audit, cargo-deny, and cargo-outdated against the current
-# checkout and emits a structured Markdown report on stdout. Exit code:
-#   0  — no findings worth blocking on
+# Thin backwards-compatible wrapper that runs all three dep-audit tools
+# in sequence by invoking scripts/dep-audit/run-one.sh once per tool,
+# and emits a single combined Markdown report on stdout. The CI workflow
+# uses run-one.sh directly via a matrix strategy; this wrapper exists
+# for local invocation.
+#
+# Exit codes:
+#   0  — all tools clean
 #   1  — at least one cargo-audit advisory or cargo-deny error
-#
-# The workflow at .github/workflows/dep-audit.yml expects the report on
-# stdout and posts it as a PR comment.
-#
-# This is the basic dep-audit pass. The dep-checksum tripwire that
-# detects same-version-different-bytes attacks (issue #6) is layered
-# on later as a separate workflow.
 
 set -uo pipefail
 
-# Force cargo and downstream tools to never emit ANSI color codes. Without
-# this, cargo tree / cargo audit emit \x1b[...m sequences that survive into
-# the Markdown report, break the grep parsing of cargo tree output, and
-# render as garbage in the PR comment body.
+# Mirror run-one.sh's color suppression so a direct local invocation of
+# this wrapper emits an ANSI-free report even when the caller's shell
+# defaults differ.
 export CARGO_TERM_COLOR=never
 export NO_COLOR=1
 export CLICOLOR=0
 
-# Locate the repo root from this script's location, so the script can be
-# run from any directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}"
 
-# Audit ignores: known advisories tracked separately. Each entry has a
-# comment naming the tracking issue. Lifted as the underlying upgrades
-# land. See ErgodicLabs/btt#11 for the wasmtime/subxt upgrade tracker.
-AUDIT_IGNORES=(
-  # wasmtime 8.0.1 vulnerabilities (transitive via subxt 0.38.1 -> sp-core);
-  # btt does not execute wasm at runtime; tracked in #11
-  RUSTSEC-2023-0091
-  RUSTSEC-2024-0438
-  RUSTSEC-2025-0118
-  RUSTSEC-2026-0020
-  RUSTSEC-2026-0021
-  RUSTSEC-2026-0085
-  RUSTSEC-2026-0086
-  RUSTSEC-2026-0087
-  RUSTSEC-2026-0088
-  RUSTSEC-2026-0089
-  RUSTSEC-2026-0091
-  RUSTSEC-2026-0092
-  RUSTSEC-2026-0093
-  RUSTSEC-2026-0094
-  RUSTSEC-2026-0095
-  RUSTSEC-2026-0096
-  # bincode 1.x EOL / wasmtime-jit transitive — #11
-  RUSTSEC-2024-0388
-  RUSTSEC-2025-0141
-  # Unmaintained crates pulled in transitively — #11
-  RUSTSEC-2020-0168  # mach
-  RUSTSEC-2022-0061  # parity-wasm
-  RUSTSEC-2022-0080  # proc-macro-error
-  RUSTSEC-2023-0037  # bigdecimal
-  RUSTSEC-2024-0370  # proc-macro-error variant
-  RUSTSEC-2024-0436  # paste
-  RUSTSEC-2024-0442  # backoff
-  RUSTSEC-2025-0057  # fxhash
-  RUSTSEC-2026-0002  # derivative
-  RUSTSEC-2026-0097  # instant
-)
-
-audit_ignore_args=()
-for id in "${AUDIT_IGNORES[@]}"; do
-  audit_ignore_args+=("--ignore" "${id}")
-done
-
-# Output goes to stdout; tool stderr goes to stderr (captured separately
-# in CI). The exit status is the union of the tool exit codes.
-exit_status=0
-
 emit() { printf '%s\n' "$*"; }
+
+RUN_ONE="${SCRIPT_DIR}/run-one.sh"
+if [ ! -x "${RUN_ONE}" ]; then
+  # Fall back to bash invocation if the executable bit is not set.
+  RUN_ONE=(bash "${SCRIPT_DIR}/run-one.sh")
+else
+  RUN_ONE=("${RUN_ONE}")
+fi
 
 emit '## Dep audit'
 emit ''
 emit "Run against \`$(git rev-parse --short HEAD)\` on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\`."
 emit ''
 
-# ---------------------------------------------------------------------
-# Direct deps inventory
-# ---------------------------------------------------------------------
-emit '### Direct deps'
-emit ''
-emit '```'
-cargo tree --depth 1 --quiet 2>/dev/null || emit '(cargo tree failed)'
-emit '```'
-emit ''
+exit_status=0
 
-# Count direct deps for the summary line. cargo tree's tree-drawing
-# characters are emitted with leading whitespace; match anything that
-# starts with a tree-corner glyph anywhere on the line.
-direct_count="$(cargo tree --depth 1 --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
-total_count="$(cargo tree --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
-emit "Total: ${direct_count:-0} direct, ${total_count:-0} entries in resolved tree (transitive)."
-emit ''
-
-# ---------------------------------------------------------------------
-# cargo-audit (rustsec advisory db)
-# ---------------------------------------------------------------------
-emit '### cargo-audit'
-emit ''
-emit '```'
-audit_output="$(cargo audit --quiet "${audit_ignore_args[@]}" 2>&1)"
-audit_status=$?
-emit "${audit_output}"
-emit '```'
-if [ ${audit_status} -ne 0 ]; then
-  emit ''
-  emit '**FAIL**: cargo-audit reported one or more advisories.'
-  exit_status=1
-else
-  emit ''
-  emit '✅ no advisories.'
-fi
-emit ''
-
-# ---------------------------------------------------------------------
-# cargo-deny (licenses, advisories, bans, sources)
-# ---------------------------------------------------------------------
-emit '### cargo-deny'
-emit ''
-DENY_CONFIG="${SCRIPT_DIR}/deny.toml"
-if [ ! -f "${DENY_CONFIG}" ]; then
-  emit "(no deny.toml at ${DENY_CONFIG}, skipping)"
-else
-  emit '```'
-  # cargo-deny argument order: subcommand first, options after.
-  deny_output="$(cargo deny check --config "${DENY_CONFIG}" 2>&1)"
-  deny_status=$?
-  emit "${deny_output}"
-  emit '```'
-  if [ ${deny_status} -ne 0 ]; then
-    emit ''
-    emit '**FAIL**: cargo-deny reported one or more issues.'
+for tool in cargo-audit cargo-deny cargo-outdated; do
+  "${RUN_ONE[@]}" "${tool}"
+  tool_status=$?
+  if [ ${tool_status} -ne 0 ]; then
     exit_status=1
-  else
-    emit ''
-    emit '✅ no issues.'
   fi
-fi
-emit ''
+  emit ''
+done
 
-# ---------------------------------------------------------------------
-# cargo-outdated (informational, never blocks)
-# ---------------------------------------------------------------------
-emit '### cargo-outdated'
-emit ''
-emit '```'
-outdated_output="$(cargo outdated --depth 1 --root-deps-only 2>&1 || true)"
-emit "${outdated_output}"
-emit '```'
-emit ''
-emit '_cargo-outdated is informational only and does not affect the audit status._'
-emit ''
-
-# ---------------------------------------------------------------------
-# Final status line (parsed by the workflow)
-# ---------------------------------------------------------------------
 if [ ${exit_status} -eq 0 ]; then
   emit 'STATUS: PASS'
 else

--- a/scripts/dep-audit/run-one.sh
+++ b/scripts/dep-audit/run-one.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# scripts/dep-audit/run-one.sh <tool>
+#
+# Runs ONE of cargo-audit, cargo-deny, or cargo-outdated against the
+# current checkout and emits that tool's Markdown section on stdout.
+# Exits 0 on clean, 1 if the tool reports a blocking finding (cargo-audit
+# advisory or cargo-deny error). cargo-outdated is informational and
+# always exits 0.
+#
+# The matrix dep-audit workflow invokes this once per matrix cell so the
+# three tools run in parallel. The legacy audit.sh wrapper chains all
+# three for local use.
+
+set -uo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <cargo-audit|cargo-deny|cargo-outdated>" >&2
+  exit 2
+fi
+
+TOOL="$1"
+
+# Force cargo and downstream tools to never emit ANSI color codes. Without
+# this, cargo tree / cargo audit emit \x1b[...m sequences that survive into
+# the Markdown report, break the grep parsing of cargo tree output, and
+# render as garbage in the PR comment body.
+export CARGO_TERM_COLOR=never
+export NO_COLOR=1
+export CLICOLOR=0
+
+# Locate the repo root from this script's location, so the script can be
+# run from any directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+emit() { printf '%s\n' "$*"; }
+
+# Audit ignores: known advisories tracked separately. Each entry has a
+# comment naming the tracking issue. Lifted as the underlying upgrades
+# land. See ErgodicLabs/btt#11 for the wasmtime/subxt upgrade tracker.
+AUDIT_IGNORES=(
+  # wasmtime 8.0.1 vulnerabilities (transitive via subxt 0.38.1 -> sp-core);
+  # btt does not execute wasm at runtime; tracked in #11
+  RUSTSEC-2023-0091
+  RUSTSEC-2024-0438
+  RUSTSEC-2025-0118
+  RUSTSEC-2026-0020
+  RUSTSEC-2026-0021
+  RUSTSEC-2026-0085
+  RUSTSEC-2026-0086
+  RUSTSEC-2026-0087
+  RUSTSEC-2026-0088
+  RUSTSEC-2026-0089
+  RUSTSEC-2026-0091
+  RUSTSEC-2026-0092
+  RUSTSEC-2026-0093
+  RUSTSEC-2026-0094
+  RUSTSEC-2026-0095
+  RUSTSEC-2026-0096
+  # bincode 1.x EOL / wasmtime-jit transitive — #11
+  RUSTSEC-2024-0388
+  RUSTSEC-2025-0141
+  # Unmaintained crates pulled in transitively — #11
+  RUSTSEC-2020-0168  # mach
+  RUSTSEC-2022-0061  # parity-wasm
+  RUSTSEC-2022-0080  # proc-macro-error
+  RUSTSEC-2023-0037  # bigdecimal
+  RUSTSEC-2024-0370  # proc-macro-error variant
+  RUSTSEC-2024-0436  # paste
+  RUSTSEC-2024-0442  # backoff
+  RUSTSEC-2025-0057  # fxhash
+  RUSTSEC-2026-0002  # derivative
+  RUSTSEC-2026-0097  # instant
+)
+
+run_audit() {
+  # cargo-audit section, prefixed by a direct-deps inventory so the
+  # audited surface is visible alongside the advisory output.
+  emit '### Direct deps'
+  emit ''
+  emit '```'
+  cargo tree --depth 1 --quiet 2>/dev/null || emit '(cargo tree failed)'
+  emit '```'
+  emit ''
+
+  # Count direct deps for the summary line. cargo tree's tree-drawing
+  # characters are emitted with leading whitespace; match anything that
+  # starts with a tree-corner glyph anywhere on the line.
+  local direct_count total_count
+  direct_count="$(cargo tree --depth 1 --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
+  total_count="$(cargo tree --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
+  emit "Total: ${direct_count:-0} direct, ${total_count:-0} entries in resolved tree (transitive)."
+  emit ''
+
+  emit '### cargo-audit'
+  emit ''
+  emit '```'
+  local audit_ignore_args=()
+  local id
+  for id in "${AUDIT_IGNORES[@]}"; do
+    audit_ignore_args+=("--ignore" "${id}")
+  done
+  local audit_output audit_status
+  audit_output="$(cargo audit --quiet "${audit_ignore_args[@]}" 2>&1)"
+  audit_status=$?
+  emit "${audit_output}"
+  emit '```'
+  if [ ${audit_status} -ne 0 ]; then
+    emit ''
+    emit '**FAIL**: cargo-audit reported one or more advisories.'
+    return 1
+  fi
+  emit ''
+  emit 'no advisories.'
+  return 0
+}
+
+run_deny() {
+  emit '### cargo-deny'
+  emit ''
+  local deny_config="${SCRIPT_DIR}/deny.toml"
+  if [ ! -f "${deny_config}" ]; then
+    emit "(no deny.toml at ${deny_config}, skipping)"
+    return 0
+  fi
+  emit '```'
+  # cargo-deny argument order: subcommand first, options after.
+  local deny_output deny_status
+  deny_output="$(cargo deny check --config "${deny_config}" 2>&1)"
+  deny_status=$?
+  emit "${deny_output}"
+  emit '```'
+  if [ ${deny_status} -ne 0 ]; then
+    emit ''
+    emit '**FAIL**: cargo-deny reported one or more issues.'
+    return 1
+  fi
+  emit ''
+  emit 'no issues.'
+  return 0
+}
+
+run_outdated() {
+  emit '### cargo-outdated'
+  emit ''
+  emit '```'
+  local outdated_output
+  outdated_output="$(cargo outdated --depth 1 --root-deps-only 2>&1 || true)"
+  emit "${outdated_output}"
+  emit '```'
+  emit ''
+  emit '_cargo-outdated is informational only and does not affect the audit status._'
+  return 0
+}
+
+case "${TOOL}" in
+  cargo-audit)
+    run_audit
+    exit $?
+    ;;
+  cargo-deny)
+    run_deny
+    exit $?
+    ;;
+  cargo-outdated)
+    run_outdated
+    exit $?
+    ;;
+  *)
+    echo "unknown tool: ${TOOL}" >&2
+    echo "usage: $0 <cargo-audit|cargo-deny|cargo-outdated>" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/dep-audit/tool-versions.txt
+++ b/scripts/dep-audit/tool-versions.txt
@@ -1,0 +1,3 @@
+cargo-audit = 0.21.2
+cargo-deny = 0.16.4
+cargo-outdated = 0.16.0

--- a/scripts/dep-audit/tool-versions.txt
+++ b/scripts/dep-audit/tool-versions.txt
@@ -1,3 +1,3 @@
-cargo-audit = 0.21.2
-cargo-deny = 0.16.4
-cargo-outdated = 0.16.0
+cargo-audit = 0.22.1
+cargo-deny = 0.19.1
+cargo-outdated = 0.18.0


### PR DESCRIPTION
[cryptid]

Closes #15.

## Summary

Splits the dep-audit workflow into a three-cell matrix (`cargo-audit`, `cargo-deny`, `cargo-outdated`) that runs in parallel, plus a `combine` job that concatenates the per-tool reports into a single PR comment under the existing `<!-- cryptid-dep-audit -->` marker. Also pins tool versions in `scripts/dep-audit/tool-versions.txt` and rewrites the cache key to hash that file so bumps invalidate cleanly.

Wall time on the warm-cache path becomes `max(audit, deny, outdated) + combine` instead of the roughly ten-minute sequential sum.

## Acceptance criteria

- [x] Three tools run in parallel matrix jobs
- [x] Combine job posts a single PR comment with all three reports
- [x] Cache key includes a hash of the tool versions file
- [x] Tool versions are pinned in `tool-versions.txt` and the install commands read from it
- [x] Wall time on warm-cache run is < 5 min — cold-cache run 24351199503 measured at ~4m56s wall (max matrix leg 286s + combine 10s); warm cache will skip the `cargo install` step entirely once the cache scope populates post-merge
- [x] CI evidence: successful run linked below

## Files changed

- `scripts/dep-audit/tool-versions.txt` (new) — pins `cargo-audit = 0.22.1`, `cargo-deny = 0.19.1`, `cargo-outdated = 0.18.0` as the single source of truth for both the cache-key hash and the install command version.
- `scripts/dep-audit/run-one.sh` (new) — takes one of the three tool names and emits that tool's Markdown section on stdout, exiting with the tool's blocking status. Shared color-suppression env, shared repo-root detection, shared advisory ignore list.
- `scripts/dep-audit/audit.sh` — reduced to a thin wrapper that chains `run-one.sh cargo-audit && run-one.sh cargo-deny && run-one.sh cargo-outdated`, writes the `## Dep audit` header and `STATUS: PASS|FAIL` footer, and returns the union exit code. Preserved for local use.
- `.github/workflows/dep-audit.yml` — restructured into:
  - `audit` matrix job (`fail-fast: false`, tools = `[cargo-audit, cargo-deny, cargo-outdated]`), per-tool cache at `~/.cargo/bin/${tool}` with key `cargo-${tool}-${runner.os}-${hashFiles('scripts/dep-audit/tool-versions.txt')}`, per-tool install via `cargo install --locked --version <version> <tool>` with the version parsed from the pinned file via awk, runs `run-one.sh`, uploads `report-*.md` / `stderr-*.log` / `status-*.txt`.
  - `combine` job (`needs: [audit], if: always()`), downloads all `dep-audit-*-${run_id}` artifacts via `actions/download-artifact@v4` with a `pattern:` filter, concatenates the per-tool reports in a fixed order under a shared header, reuses the existing find-comment / create-or-update logic via `actions/github-script@v7`, uploads a combined artifact, and fails the job when any tool's status sidecar is non-zero so the union status propagates.
- Triggers preserved: `pull_request`, `push: [main]`, weekly Sunday cron, `workflow_dispatch` with the documented `verbose` input.

## Tested locally (structural only)

- `bash -n scripts/dep-audit/run-one.sh` and `bash -n scripts/dep-audit/audit.sh` — clean.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dep-audit.yml'))"` — parses clean, `jobs = [audit, combine]`, matrix strategy resolves to the three tool names, combine `needs: [audit]`.
- `awk -v t=<tool> '$1 == t { print $3; exit }' scripts/dep-audit/tool-versions.txt` — returns `0.22.1`, `0.19.1`, `0.18.0` for the three tools respectively.
- `run-one.sh` with no args and with an unknown tool exits `2` with a usage line, as expected.

No cargo tools were installed on the cryptid host; the actual tool runs happen in CI per the no-local-verification-deps rule.

## CI evidence

- First structural run: https://github.com/ErgodicLabs/btt/actions/runs/24350869070 — matrix parallelism, artifact fan-in, combine job, and PR comment all worked as designed. Surfaced a real regression: cargo-audit `0.21.2` and cargo-deny `0.16.4` both ship an old `rustsec` advisory-db parser that cannot parse the current `libcrux-poly1305/RUSTSEC-2026-0073.md` advisory (TOML parse error at line 5). Fix committed as [`c264c38`](https://github.com/ErgodicLabs/btt/commit/c264c38) bumping to `cargo-audit 0.22.1` / `cargo-deny 0.19.1` / `cargo-outdated 0.18.0`, which is exactly the bump-and-invalidate flow the new pinned-key design is meant to cover.
- Successful green PR run: https://github.com/ErgodicLabs/btt/actions/runs/24351199503 — three matrix cells concurrent, combine aggregates all three reports, single PR comment posted, `STATUS: PASS`. Cold-cache wall time ≈4m56s (max matrix leg 286s + 10s combine) versus the prior ≈10m sequential run, meeting the <5 min target on cold cache.
- Warm-cache workflow_dispatch run: https://github.com/ErgodicLabs/btt/actions/runs/24351454565 — also green. Note: GitHub Actions scopes cache by ref, so `pull_request`-saved caches do not restore into `workflow_dispatch` runs on the branch ref; the warm-cache shortcut will kick in after merge when future PRs hit the `main`-scoped cache.

## Test plan

- [x] Three matrix jobs visible as parallel boxes in the GH Actions UI
- [x] Each matrix job's logs show only one tool running
- [x] `combine` job downloads all three artifacts and posts a single PR comment containing all three sections plus the `STATUS:` line
- [x] Overall workflow status equals the union of the three tool statuses (verified by the first run failing on the rustsec parser bug and the second run passing once the tools were bumped)
- [x] Cold-cache wall time under five minutes