### PR TITLE
[cryptid] clippy: clean up stake.rs lints introduced by the dTAO rewrite (#24)

### DIFF
--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -147,10 +147,10 @@ pub async fn list(
 
     let mut prices: BTreeMap<u16, Option<f64>> = BTreeMap::new();
     for entry in &raw {
-        if !prices.contains_key(&entry.netuid) {
+        if let std::collections::btree_map::Entry::Vacant(slot) = prices.entry(entry.netuid) {
             // Failure of one price fetch must not drop the whole list.
             let price = fetch_subnet_price(&storage, entry.netuid).await.ok().flatten();
-            prices.insert(entry.netuid, price);
+            slot.insert(price);
         }
     }
 
@@ -340,7 +340,19 @@ pub async fn add(
         ],
     );
 
-    submit_stake_tx(&api, &tx, &signer, "add_stake", amount_rao, "tao", hotkey, netuid).await
+    submit_stake_tx(
+        &api,
+        &tx,
+        &signer,
+        StakeTxMeta {
+            action: "add_stake",
+            amount_rao,
+            amount_unit: "tao",
+            hotkey,
+            netuid,
+        },
+    )
+    .await
 }
 
 // ── remove ────────────────────────────────────────────────────────────────
@@ -459,11 +471,13 @@ pub async fn remove(
         &api,
         &tx,
         &signer,
-        "remove_stake",
-        amount_alpha_rao,
-        "alpha",
-        hotkey,
-        netuid,
+        StakeTxMeta {
+            action: "remove_stake",
+            amount_rao: amount_alpha_rao,
+            amount_unit: "alpha",
+            hotkey,
+            netuid,
+        },
     )
     .await
 }
@@ -481,8 +495,8 @@ async fn lookup_alpha_balance(
         "StakeInfoRuntimeApi",
         "get_stake_info_for_hotkey_coldkey_netuid",
         vec![
-            Value::from_bytes(hotkey_bytes.to_vec()),
-            Value::from_bytes(coldkey_bytes.to_vec()),
+            Value::from_bytes(hotkey_bytes),
+            Value::from_bytes(coldkey_bytes),
             Value::u128(netuid as u128),
         ],
     );
@@ -512,17 +526,25 @@ async fn lookup_alpha_balance(
     Ok(value_to_u64(stake_field).unwrap_or(0))
 }
 
+/// Result-envelope metadata for [`submit_stake_tx`]. Groups the per-call
+/// descriptors that get copied into the returned [`StakeTxResult`] so the
+/// helper takes a small, semantically-clustered struct instead of seven
+/// loose scalars.
+struct StakeTxMeta<'a> {
+    action: &'static str,
+    amount_rao: u64,
+    amount_unit: &'static str,
+    hotkey: &'a str,
+    netuid: u16,
+}
+
 /// Sign, submit, finalize, and convert a stake-related extrinsic into a
 /// `StakeTxResult` envelope.
 async fn submit_stake_tx(
     api: &OnlineClient<PolkadotConfig>,
     tx: &subxt::tx::DynamicPayload,
     signer: &PairSigner<PolkadotConfig, sr25519::Pair>,
-    action: &'static str,
-    amount_rao: u64,
-    amount_unit: &'static str,
-    hotkey: &str,
-    netuid: u16,
+    meta: StakeTxMeta<'_>,
 ) -> Result<StakeTxResult, BttError> {
     let progress = tokio::time::timeout(
         Duration::from_secs(120),
@@ -549,12 +571,12 @@ async fn submit_stake_tx(
     Ok(StakeTxResult {
         tx_hash,
         block: block_hash,
-        action: action.to_string(),
-        amount_rao,
-        amount: rao_to_tao_string(amount_rao),
-        amount_unit,
-        hotkey: hotkey.to_string(),
-        netuid,
+        action: meta.action.to_string(),
+        amount_rao: meta.amount_rao,
+        amount: rao_to_tao_string(meta.amount_rao),
+        amount_unit: meta.amount_unit,
+        hotkey: meta.hotkey.to_string(),
+        netuid: meta.netuid,
     })
 }
 


### PR DESCRIPTION
[cryptid]

Closes #24. Unblocks #30 (CI clippy gate).

## Summary

Four \`clippy::-D warnings\`-level errors in \`src/commands/stake.rs\`, all from the PR #23 dTAO stake-ops rewrite. CI didn't catch them because no CI workflow runs clippy yet — see #30 for the structural fix that should follow this PR.

## Fixes

- **\`clippy::map_entry\`** in \`list()\` — replace \`prices.contains_key(&netuid)\` + \`prices.insert(netuid, value)\` with the \`Entry::Vacant\` form via \`prices.entry(entry.netuid)\`. Same semantics, single hash lookup.

- **\`clippy::unnecessary_to_owned\` (×2)** in \`lookup_alpha_balance()\` — \`Value::from_bytes\` was being passed \`hotkey_bytes.to_vec()\` and \`coldkey_bytes.to_vec()\` even though the inputs are already byte slices the function can consume. Drop the redundant \`.to_vec()\` calls.

- **\`clippy::too_many_arguments\`** in \`submit_stake_tx()\` — the helper had eight parameters (\`api\`, \`tx\`, \`signer\`, \`action\`, \`amount_rao\`, \`amount_unit\`, \`hotkey\`, \`netuid\`). Group the five trailing scalars into a new \`StakeTxMeta<'a>\` struct, leaving the helper with four positional params. The grouped fields all flow into the same \`StakeTxResult\` envelope, so the cluster is semantically real, not arbitrary. Call sites in \`add()\` and \`remove()\` updated.

## Files changed

- \`src/commands/stake.rs\` — +43 / −21

No \`Cargo.toml\` change. **No new dependencies.** No behavior change. No new tests because nothing about the runtime semantics moved.

## Commits

- \`b8901f5\` — \`clippy: clean up stake.rs lints introduced by the dTAO rewrite (#24)\`

## Verification

cryptid host, main repo incremental:

- \`cargo clippy --all-targets -- -D warnings\` — exit 0 (only the pre-existing trie-db future-incompat warning, unchanged).
- \`cargo build\` and \`cargo test\` not re-run locally — incremental compile in 2.73s confirms the file parses and type-checks. **CI must run the full build+test matrix on this PR.**

## Builder context

The original opus builder subagent compiled this diff in its worktree but stalled when its \`cargo test\` was moved to a background job by the harness; the agent gave up before finalizing the commit. cryptid rescued the in-worktree diff manually, ran clippy on the main repo to confirm the lint gate passes, and committed. This is the second time a builder has hit the \"long-running cargo test in background\" pattern and given up — it's a cryptid coordination bug, not a btt bug.

## Out of scope

- Adding the clippy job to CI (issue #30, follows this PR).
- Other clippy warnings that aren't currently \`-D\` errors.

## Related

- #23 — original dTAO rewrite that introduced these lints.
- #30 — adds clippy to CI; should land after this PR so CI starts green instead of immediately broken.