### PR TITLE
[cryptid] ci: add clippy gate to lint workflow (#30)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,64 @@
+name: lint
+
+# Clippy gate. Per AGENTS.md principle 8 (lint discipline), clippy is a
+# required merge gate, not advisory: any `clippy::-D warnings`-level lint
+# on `--all-targets` blocks the PR.
+#
+# Background: issue #30. Four clippy errors in src/commands/stake.rs from
+# the PR #23 dTAO rewrite went unnoticed until PR #26's barbarian flagged
+# them, because no CI workflow ran clippy. PR #31 cleaned up those four
+# lints and unblocked this workflow landing — if we had added the gate
+# any earlier it would have broken every open PR.
+#
+# This workflow is intentionally small and does one thing. It does not
+# run `cargo build` or `cargo test` — `cargo clippy --all-targets` already
+# type-checks every target (bins, tests, benches, examples), and tests
+# will get their own job when that question is answered.
+#
+# The cargo cache key mirrors the btcli-compat workflow's scheme so a
+# clippy run on a PR that already built via btcli-compat can at least
+# share the registry/index portion of the cache.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-lint-
+
+      - name: Run clippy
+        # --all-targets so tests, benches, and examples are linted too.
+        # -D warnings promotes every remaining warning to an error, which
+        # is the whole point of the gate: a warning that isn't a gate is
+        # a warning that accumulates.
+        run: cargo clippy --all-targets -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ The rule is enforced at review time. Reviewers should reject PRs that modify str
 - Upstream incorporation on published branches: `merge main`, not rebase.
 - Commit messages describe the specific commit's change, concisely and precisely.
 
+### 8. Lint discipline
+
+Clippy is a merge gate, not advisory. The `lint` workflow in `.github/workflows/lint.yml` runs `cargo clippy --all-targets -- -D warnings` on every PR and on every push to `main`. Any `clippy::-D warnings`-level lint — style, correctness, perf, suspicious, anything in the default set — fails the gate and blocks merge.
+
+Rationale: during the PR #23 dTAO stake-ops rewrite, four clippy errors slipped into `src/commands/stake.rs` and survived several subsequent merges because no CI job ran clippy. They were only caught by the PR #26 barbaric review. Lint regressions that are not mechanically prevented will accumulate; issue #30 closed that gap.
+
+If a specific lint is wrong for a specific site, the correct response is a narrowly scoped `#[allow(clippy::whatever)]` with a comment explaining why, not disabling the gate. Blanket `#![allow(...)]` at the crate root is forbidden.
+
 ## Relationship to cryptid
 
 `btt` is developed and reviewed by cryptid, a web3 security research agent, in cooperation with human operators at Ergodic Labs. Cryptid enforces the principles above through automated barbaric review. The project principles are also stored in cryptid's knowledge database under the `cryptid-project-principle` kind, keyed as `btt-*`, so they persist across sessions and can be queried by any agent working on the project.


### PR DESCRIPTION
[cryptid]

Closes #30.

## Summary

Adds `.github/workflows/lint.yml` with a single `clippy` job that runs on every pull request, every push to `main`, and on manual `workflow_dispatch`. The job runs:

```
cargo clippy --all-targets -- -D warnings
```

Any `clippy::-D warnings`-level lint — style, correctness, perf, suspicious, the default set — fails the gate and blocks merge.

## Ordering

This PR is only safe to land because #24 / #31 (merged in `a62a3d7`) cleaned up the four pre-existing `clippy::-D warnings` errors in `src/commands/stake.rs` left over from the PR #23 dTAO stake-ops rewrite. Confirmed locally on `a62a3d7`:

```
$ cargo clippy --all-targets -- -D warnings
    Checking btt v0.1.0
    Finished `dev` profile ... target(s) in 2.44s
$ echo $?
0
```

If this PR had been opened before #31 merged, the gate would have failed on the first run and broken every open PR.

## Workflow shape

- Trigger: `pull_request`, `push` to `main`, `workflow_dispatch`.
- Runner: `ubuntu-latest` (matches `dep-audit.yml` and `btcli-compat.yml`).
- Toolchain: `dtolnay/rust-toolchain@stable` with the `clippy` component. There is no `rust-toolchain.toml` in the repo; stable matches what both existing workflows use.
- Cache: `actions/cache@v4` keyed on `${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}`, mirroring the scheme in `btcli-compat.yml`. The cache covers `~/.cargo/{bin,registry/{index,cache},git/db}` and `target/`.
- Single step: `cargo clippy --all-targets -- -D warnings`.
- `permissions: contents: read`. The job does not post comments.
- `timeout-minutes: 20`.

No existing workflow is modified.

## Why a new workflow file rather than appending to an existing one

Issue #30 refers to a `verify.yml` running `cargo build` + `cargo test`. That file does not exist in the tree — the only workflows today are `dep-audit.yml` and `btcli-compat.yml`, and neither is a general verify job. A dedicated `lint.yml` keeps the clippy gate independent of the supply-chain audit and the btcli keyfile compat check; when a real verify/test workflow lands it can live alongside or absorb this one without dragging in unrelated concerns.

## Hypothetical lint regression

If a future PR lands a clippy lint in, say, `src/commands/foo.rs`:

```
error: unnecessary use of `to_vec`
  --> src/commands/foo.rs:42:13
   |
42 |             bytes.to_vec()
   |             ^^^^^^^^^^^^^^ help: use: `bytes`
   = note: `-D clippy::unnecessary-to-owned` implied by `-D warnings`

error: could not compile `btt` (bin "btt") due to 1 previous error
```

The `clippy` job exits non-zero, the check appears red on the PR, and if branch protection includes the check, merge is blocked until the PR either fixes the lint or adds a narrowly scoped `#[allow(clippy::unnecessary_to_owned)]` with justification.

## AGENTS.md update

Adds a new principle 8 (Lint discipline) documenting that clippy is a merge gate, not advisory, and that targeted `#[allow(clippy::whatever)]` with a comment is the correct escape hatch — crate-root blanket allows are forbidden. Rationale block references the PR #23 -> PR #26 -> #30 sequence so future readers understand why the gate exists.

## Branch protection

If branch protection for `main` is managed via the GitHub UI rather than in code, @zomglings will need to add the `clippy` check (from workflow `lint`) to the required status checks list manually. I did not find a `.github/branch-protection.yml` or similar config in the tree, so I assume it is UI-managed. Until the check is added to branch protection, the gate runs and shows red on regressions but does not mechanically block merge.

## Files changed

- `.github/workflows/lint.yml` (new, 63 lines)
- `AGENTS.md` (+8 lines, new principle 8)

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` — parses clean.
- `cargo clippy --all-targets -- -D warnings` on the branch tip — exit 0.
- `cargo test` intentionally not run: this is a CI-config PR, no source touched outside `AGENTS.md`.

## Non-goals

- No changes to `verify`/build/test jobs (none exist yet to modify).
- No new dependencies.
- No refactor of existing workflows.
- No merge.