### PR TITLE
[cryptid] ci: pin rust toolchain and add --all-features to clippy gate (#33)

### DIFF
--- a/.github/workflows/btcli-compat.yml
+++ b/.github/workflows/btcli-compat.yml
@@ -56,7 +56,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to match rust-toolchain.toml. When bumping, update both.
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: clippy
 

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -50,7 +50,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to match rust-toolchain.toml. When bumping, update both.
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache ${{ matrix.tool }} binary
         id: tool-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to match rust-toolchain.toml. When bumping, update both.
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: clippy
 
@@ -58,7 +59,10 @@ jobs:
 
       - name: Run clippy
         # --all-targets so tests, benches, and examples are linted too.
+        # --all-features so feature-gated code paths are also linted; today
+        # btt has no [features] table so this is a no-op, but the moment a
+        # feature is added the gate stays honest. Issue #33 follow-up.
         # -D warnings promotes every remaining warning to an error, which
         # is the whole point of the gate: a warning that isn't a gate is
         # a warning that accumulates.
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# Pinned toolchain for btt.
+#
+# Issue #33 fix: the project previously used `dtolnay/rust-toolchain@stable`
+# in every workflow. Floating `stable` means a Rust release with a new
+# default clippy lint will simultaneously break every CI workflow with no
+# warning and no clear fix path.
+#
+# Pinning here makes Rust version bumps explicit PRs that can be tested in
+# isolation. The CI workflows pin the same version via
+# `dtolnay/rust-toolchain@<version>` so local dev and CI agree.
+#
+# When bumping: update this file AND every `.github/workflows/*.yml` that
+# pins `dtolnay/rust-toolchain@<version>`. They must move together.
+
+[toolchain]
+channel = "1.94.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
[cryptid]

Closes #33.

## Summary

Two LOW findings from the PR #32 barbarian deferred to issue #33:

1. **\`--all-features\` was dropped from the clippy command.** No-op today (\`Cargo.toml\` has no \`[features]\` table) but future-fragile: the moment a feature is added, the gate would silently stop checking the off-by-default code path.
2. **\`dtolnay/rust-toolchain@stable\` floats** in every workflow. A new stable Rust release with a new default clippy lint would simultaneously break every CI workflow — three jobs failing at once with no warning and no clean revert path.

Both fixed here.

## Changes

- **New \`rust-toolchain.toml\`** at the repo root pins channel \`1.94.1\`, includes \`clippy\` and \`rustfmt\` components, uses the \`minimal\` profile. \`cargo\` picks this up on local dev so contributors get the same toolchain as CI without an explicit \`rustup install\` step. The file documents the bump procedure inline.
- **\`.github/workflows/lint.yml\`**: pin to \`dtolnay/rust-toolchain@1.94.1\` and add \`--all-features\` to the clippy command. New comment explains why \`--all-features\` is a no-op today and a guarantee tomorrow.
- **\`.github/workflows/btcli-compat.yml\`**: pin to \`@1.94.1\`.
- **\`.github/workflows/dep-audit.yml\`**: pin to \`@1.94.1\`.

Each pin is annotated with a comment instructing the next bumper to update both the workflow AND \`rust-toolchain.toml\` together. Splitting the bump across PRs would briefly produce a divergence between local and CI toolchains, which is exactly what this issue was filed to prevent.

## Files changed

- \`rust-toolchain.toml\` (new, 17 lines)
- \`.github/workflows/lint.yml\` (+9 / −2)
- \`.github/workflows/btcli-compat.yml\` (+2 / −1)
- \`.github/workflows/dep-audit.yml\` (+2 / −1)

Net: 4 files, +28 / −4. **No source code touched. No new dependencies. No behavior change.**

## Verification (cryptid host)

- \`python3 -c \"import yaml; yaml.safe_load(...)\"\` parses all three workflow files.
- \`rustup\` auto-synced 1.94.1 from the new \`rust-toolchain.toml\` on the first \`cargo\` invocation.
- \`cargo clippy --all-targets --all-features -- -D warnings\` exit 0 on this branch (only the pre-existing \`trie-db v0.29.1\` future-incompat notice, which is a cargo-level diagnostic and not a clippy lint).

## Builder context

This PR was hand-written by cryptid (not a builder subagent) because the diff is config-only and a 4-line edit isn't worth a 12-minute opus dispatch. The barbarian review is still spawned per the loop rule.

## Out of scope

- Bumping to a newer Rust version (this PR pins to what CI is currently running, no behavior change).
- Adding any actual \`[features]\` to \`Cargo.toml\`.
- Branch protection (UI-managed; the \`clippy\` job will continue to run and show red/green; mechanical blocking still requires a one-time UI add).

## Related

- Issue #30, PR #32 (the original CI clippy gate).
- Issue #33 (this PR's tracking issue, opened with the deferred LOW findings).