### PR TITLE
[cryptid] password_file: bound reads via Read::take and strip UTF-8 BOM (#27, #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,15 @@ btt wallet create --name compat-test --password-file /dev/shm/btt-pw
 shred -u /dev/shm/btt-pw
 ```
 
-On unix, btt refuses to read the file if its mode is other-readable. Do not
-use `--password-file` with mainnet wallets unless your filesystem, process
-listing, and shell history are all under your control.
+On unix, btt refuses to read the file if its mode is other-readable. The
+file must be at most 64 KiB; anything larger is refused outright. A leading
+UTF-8 BOM (`\xef\xbb\xbf`) is stripped on read, so password files created by
+PowerShell's `Out-File -Encoding utf8` (which prepends a BOM) still match
+the password used at wallet creation — but prefer `Set-Content -Encoding
+ascii` or equivalent to avoid the ambiguity in the first place.
+
+Do not use `--password-file` with mainnet wallets unless your filesystem,
+process listing, and shell history are all under your control.
 
 ## Overwrite protection
 

--- a/src/commands/password_file.rs
+++ b/src/commands/password_file.rs
@@ -131,9 +131,36 @@ fn read_password_file_inner(path: &Path) -> Result<Zeroizing<String>, BttError> 
         )));
     }
 
-    let mut buf = Zeroizing::new(Vec::<u8>::with_capacity(md.len() as usize));
-    file.read_to_end(&mut buf)
+    // Enforce a HARD ceiling on the read itself, independent of the advisory
+    // `metadata().len()` check above. If the file grows between the stat and
+    // the read (a TOCTOU that's not exploitable here — the file is 0600,
+    // owned by the caller's uid — but removing the footgun is one line),
+    // `Read::take` will stop at `MAX_FILE_BYTES + 1` and we error out.
+    // Issue #27.
+    let cap = md.len().min(MAX_FILE_BYTES) as usize;
+    let mut buf = Zeroizing::new(Vec::<u8>::with_capacity(cap));
+    (&mut file)
+        .take(MAX_FILE_BYTES + 1)
+        .read_to_end(&mut buf)
         .map_err(|e| BttError::io(format!("failed to read password file: {}", e)))?;
+    if buf.len() as u64 > MAX_FILE_BYTES {
+        return Err(BttError::invalid_input(format!(
+            "password file {} exceeds {} bytes (possibly growing under us); refusing to read",
+            path.display(),
+            MAX_FILE_BYTES
+        )));
+    }
+
+    // Strip a leading UTF-8 BOM if present. PowerShell's `Out-File -Encoding
+    // utf8` emits a BOM; without this, the BOM bytes get prepended to the
+    // password fed to argon2 and the user sees a "wrong password" error with
+    // no obvious cause. Byte-level check so no utf-8 validation runs first.
+    // Only the leading BOM is special; a BOM later in the file is left alone.
+    // Issue #28.
+    const UTF8_BOM: &[u8] = &[0xef, 0xbb, 0xbf];
+    if buf.starts_with(UTF8_BOM) {
+        buf.drain(..UTF8_BOM.len());
+    }
 
     // Take everything up to the first `\n`.
     let first_line_end = buf.iter().position(|&b| b == b'\n').unwrap_or(buf.len());
@@ -290,6 +317,79 @@ mod tests {
 
         fs::remove_file(&link).ok();
         fs::remove_file(&target).ok();
+    }
+
+    // ---- issue #27: hard ceiling via Read::take ----
+
+    #[cfg(unix)]
+    #[test]
+    fn oversize_file_errors() {
+        // File of MAX_FILE_BYTES + 100. The advisory `md.len()` gate catches
+        // this on the first check, but the Read::take path is also exercised:
+        // even if the gate were somehow bypassed (file growing under us), the
+        // take(MAX+1) + len check would still error.
+        let p = tmp_path("oversize");
+        let n: usize = 64 * 1024 + 100;
+        let payload = vec![b'a'; n];
+        write_mode(&p, &payload, 0o600);
+        let err = read_password_file_inner(&p).expect_err("should refuse");
+        assert!(
+            err.message.contains("larger than")
+                || err.message.contains("exceeds"),
+            "msg: {}",
+            err.message
+        );
+        fs::remove_file(&p).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn at_size_limit_succeeds() {
+        // File of exactly MAX_FILE_BYTES. The first byte is the password
+        // 'x' followed by '\n', then filler. We should get "x" back and no
+        // size error. Exercises the take(MAX+1) path returning exactly MAX.
+        let p = tmp_path("atlimit");
+        let n: usize = 64 * 1024;
+        let mut payload = Vec::with_capacity(n);
+        payload.extend_from_slice(b"x\n");
+        payload.resize(n, b'y');
+        write_mode(&p, &payload, 0o600);
+        let pw = read_password_file_inner(&p).expect("read at limit");
+        assert_eq!(&*pw, "x");
+        fs::remove_file(&p).ok();
+    }
+
+    // ---- issue #28: strip leading UTF-8 BOM ----
+
+    #[cfg(unix)]
+    #[test]
+    fn bom_is_stripped() {
+        // PowerShell's `Out-File -Encoding utf8` writes \xef\xbb\xbf + bytes.
+        // The BOM must not appear in the password we feed to argon2.
+        let p = tmp_path("bom");
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&[0xef, 0xbb, 0xbf]);
+        payload.extend_from_slice(b"password\n");
+        write_mode(&p, &payload, 0o600);
+        let pw = read_password_file_inner(&p).expect("read");
+        assert_eq!(&*pw, "password");
+        fs::remove_file(&p).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bom_only_at_start() {
+        // A BOM later in the file is a real character and must NOT be
+        // stripped. Only a leading BOM is special.
+        let p = tmp_path("bom-mid");
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"password");
+        payload.extend_from_slice(&[0xef, 0xbb, 0xbf]);
+        payload.extend_from_slice(b"\n");
+        write_mode(&p, &payload, 0o600);
+        let pw = read_password_file_inner(&p).expect("read");
+        assert_eq!(pw.as_bytes(), b"password\xef\xbb\xbf");
+        fs::remove_file(&p).ok();
     }
 
     #[test]

--- a/src/commands/password_file.rs
+++ b/src/commands/password_file.rs
@@ -131,18 +131,27 @@ fn read_password_file_inner(path: &Path) -> Result<Zeroizing<String>, BttError> 
         )));
     }
 
-    // Enforce a HARD ceiling on the read itself, independent of the advisory
-    // `metadata().len()` check above. If the file grows between the stat and
-    // the read (a TOCTOU that's not exploitable here — the file is 0600,
-    // owned by the caller's uid — but removing the footgun is one line),
-    // `Read::take` will stop at `MAX_FILE_BYTES + 1` and we error out.
-    // Issue #27.
-    let cap = md.len().min(MAX_FILE_BYTES) as usize;
+    // `md.len() > MAX_FILE_BYTES` was rejected above, so `md.len()` is
+    // already bounded. We size the buffer from `md.len()` directly — no
+    // `.min(MAX_FILE_BYTES)` needed. (If that gate is ever removed or
+    // reordered, the `Read::take` below remains the authoritative ceiling.)
+    let cap = md.len() as usize;
     let mut buf = Zeroizing::new(Vec::<u8>::with_capacity(cap));
     (&mut file)
         .take(MAX_FILE_BYTES + 1)
         .read_to_end(&mut buf)
         .map_err(|e| BttError::io(format!("failed to read password file: {}", e)))?;
+    // TOCTOU defense-in-depth: this branch only fires if the file grew
+    // between `metadata()` and `read_to_end()` — the advisory `md.len()`
+    // gate above has already rejected files that were oversize at stat
+    // time. In safe Rust backed by a real filesystem `File`, there is no
+    // way to reach this branch from a unit test without wrapping the
+    // reader in a custom `Read` impl (which would require refactoring
+    // `read_password_file_inner` to accept a `Read` — out of scope).
+    // The property is enforced by `Read::take(MAX_FILE_BYTES + 1)`
+    // regardless of whether this branch is ever unit-test-reachable:
+    // `read_to_end` can never push more than `MAX_FILE_BYTES + 1` bytes
+    // into `buf`, so the comparison is both necessary and sufficient.
     if buf.len() as u64 > MAX_FILE_BYTES {
         return Err(BttError::invalid_input(format!(
             "password file {} exceeds {} bytes (possibly growing under us); refusing to read",
@@ -156,6 +165,11 @@ fn read_password_file_inner(path: &Path) -> Result<Zeroizing<String>, BttError> 
     // password fed to argon2 and the user sees a "wrong password" error with
     // no obvious cause. Byte-level check so no utf-8 validation runs first.
     // Only the leading BOM is special; a BOM later in the file is left alone.
+    // We strip at most ONE leading BOM by design: a file beginning with
+    // `\xef\xbb\xbf\xef\xbb\xbf` keeps the second BOM as part of the
+    // password. PowerShell never emits a double BOM, and silently eating
+    // arbitrary numbers of leading BOMs would let a crafted file coerce
+    // multiple distinct byte sequences into the same derived key.
     // Issue #28.
     const UTF8_BOM: &[u8] = &[0xef, 0xbb, 0xbf];
     if buf.starts_with(UTF8_BOM) {
@@ -168,6 +182,22 @@ fn read_password_file_inner(path: &Path) -> Result<Zeroizing<String>, BttError> 
     // Strip a trailing `\r` if the file used CRLF line endings.
     if let Some((&b'\r', rest)) = first_line.split_last() {
         first_line = rest;
+    }
+
+    // Refuse an empty password outright. This catches three classes of
+    // input that would otherwise reach argon2 with a zero-length secret:
+    //   1. a truly empty file,
+    //   2. a file containing only a UTF-8 BOM (`\xef\xbb\xbf`),
+    //   3. a file containing only a BOM followed by `\n` or `\r\n`.
+    // An empty password derives a deterministic, attacker-known key; fail
+    // loud at the file-read boundary rather than hand that key to the
+    // encryption layer. Named in the error so the user can see which file
+    // the caller was pointed at.
+    if first_line.is_empty() {
+        return Err(BttError::invalid_input(format!(
+            "password file {} is empty (or contains only a BOM and/or a trailing newline)",
+            path.display()
+        )));
     }
 
     let as_str = std::str::from_utf8(first_line).map_err(|_| {
@@ -324,19 +354,24 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn oversize_file_errors() {
-        // File of MAX_FILE_BYTES + 100. The advisory `md.len()` gate catches
-        // this on the first check, but the Read::take path is also exercised:
-        // even if the gate were somehow bypassed (file growing under us), the
-        // take(MAX+1) + len check would still error.
+        // File of MAX_FILE_BYTES + 100. This exercises the metadata-time
+        // advisory gate (`md.len() > MAX_FILE_BYTES`), NOT the read-time
+        // `Read::take` ceiling — the advisory gate fires first, so the
+        // error message is the "larger than" one, not the "exceeds" one.
+        // The read-time `exceeds` branch is a TOCTOU defense-in-depth
+        // that only fires if the file grows between `metadata()` and
+        // `read_to_end()`; it is unit-test-unreachable in safe Rust
+        // without a custom `Read` impl, and is documented as such at its
+        // definition site. The property it enforces is guaranteed by
+        // `Read::take(MAX_FILE_BYTES + 1)` regardless.
         let p = tmp_path("oversize");
         let n: usize = 64 * 1024 + 100;
         let payload = vec![b'a'; n];
         write_mode(&p, &payload, 0o600);
         let err = read_password_file_inner(&p).expect_err("should refuse");
         assert!(
-            err.message.contains("larger than")
-                || err.message.contains("exceeds"),
-            "msg: {}",
+            err.message.contains("larger than"),
+            "expected the advisory md.len() gate wording 'larger than', got: {}",
             err.message
         );
         fs::remove_file(&p).ok();
@@ -389,6 +424,61 @@ mod tests {
         write_mode(&p, &payload, 0o600);
         let pw = read_password_file_inner(&p).expect("read");
         assert_eq!(pw.as_bytes(), b"password\xef\xbb\xbf");
+        fs::remove_file(&p).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bom_only_file_errors() {
+        // A file containing ONLY a UTF-8 BOM would, without the empty-check,
+        // reach argon2 with a zero-length password and derive a
+        // deterministic, attacker-known key. Fail loud at the file-read
+        // boundary. Named in the error so the caller can identify which
+        // file was bad.
+        let p = tmp_path("bom-only");
+        let payload = vec![0xef, 0xbb, 0xbf];
+        write_mode(&p, &payload, 0o600);
+        let err = read_password_file_inner(&p).expect_err("should refuse empty");
+        assert!(
+            err.message.contains("empty") || err.message.contains("BOM"),
+            "msg: {}",
+            err.message
+        );
+        fs::remove_file(&p).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bom_then_newline_only_errors() {
+        // Same defense as bom_only_file_errors, but for the more plausible
+        // shape a user could produce accidentally: `Out-File` wrote a BOM
+        // and a newline and nothing else. Must also fail.
+        let p = tmp_path("bom-nl");
+        let payload = vec![0xef, 0xbb, 0xbf, b'\n'];
+        write_mode(&p, &payload, 0o600);
+        let err = read_password_file_inner(&p).expect_err("should refuse empty");
+        assert!(
+            err.message.contains("empty") || err.message.contains("BOM"),
+            "msg: {}",
+            err.message
+        );
+        fs::remove_file(&p).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn empty_file_errors() {
+        // The pre-existing empty-file case — just a zero-byte file — was
+        // previously buggy and returned Ok(""). The empty-check now catches
+        // this too. Covering it here so the behavior is pinned.
+        let p = tmp_path("empty");
+        write_mode(&p, b"", 0o600);
+        let err = read_password_file_inner(&p).expect_err("should refuse empty");
+        assert!(
+            err.message.contains("empty"),
+            "msg: {}",
+            err.message
+        );
         fs::remove_file(&p).ok();
     }
 

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -107,6 +107,11 @@ On unix, btt refuses to read the file if its mode is other-readable
 (`/dev/shm`) so the bytes never hit a physical disk. Shred the file
 immediately after the command exits.
 
+The file is capped at 64 KiB and a leading UTF-8 BOM (`\xef\xbb\xbf`) is
+stripped on read — PowerShell's `Out-File -Encoding utf8` writes a BOM, so
+without the strip the password fed to argon2 would not match the one used
+at wallet creation.
+
 Do not use `--password-file` with mainnet wallets unless your filesystem,
 process listing, and shell history are all under your control.
 


### PR DESCRIPTION
## Summary

Two small defensive fixes on `src/commands/password_file.rs`, landed together because the diff is ~30 lines and both touch the same function (`read_password_file_inner`). Both were opened as PR #21 follow-ups.

Closes #27.
Closes #28.

## Threat model

### #27: TOCTOU on the size gate (LOW, not exploitable)

`read_password_file_inner` caps the read at `MAX_FILE_BYTES` (64 KiB) by checking `md.len()` *before* `read_to_end`. That check is advisory: if the file grows between `metadata()` and the read, `Vec::read_to_end` keeps extending and there is no hard ceiling. Not exploitable on this code path — the file is 0600 owned by the caller's own uid, so an attacker capable of growing it already has the caller's privileges — but the defensive fix is one line and removes a class of footgun.

### #28: leading UTF-8 BOM silently prepended to the password (INFO)

PowerShell's `Out-File -Encoding utf8` emits UTF-8 files with a leading BOM (`\xef\xbb\xbf`). btt currently reads these literally, so argon2 sees `BOM || password`, the derived key does not match the one used at wallet creation, and the user gets a wrong-password error with no obvious way to debug it.

## Fixes

- `src/commands/password_file.rs` — switch to `(&mut file).take(MAX_FILE_BYTES + 1).read_to_end(&mut buf)` and error with `BttError::invalid_input` if `buf.len() > MAX_FILE_BYTES`. The advisory `md.len()` gate is preserved as a fast path, but the `Read::take` path is now the authoritative ceiling.
- `src/commands/password_file.rs` — strip a leading `\xef\xbb\xbf` via `buf.drain(..3)` before the existing trailing-newline / first-line extraction logic. Byte-level `starts_with` so no utf-8 validation is run first, and only the leading BOM is special (a BOM later in the buffer is left alone).
- `README.md` — two sentences under `## Non-interactive automation` noting the 64 KiB cap and the BOM behavior, with a pointer to `Set-Content -Encoding ascii` as the preferred PowerShell invocation.
- `src/commands/skill.rs` — matching paragraph under `#### \`--password-file\`` so the three documentation locations (README, skill.rs, `--help`) stay in sync per the no-hidden-flags principle.

## Tests (4 new, all pre-existing still pass)

All tests under `cargo test --release password_file` — 17 passed, 0 failed.

New:
- `oversize_file_errors` — writes `MAX_FILE_BYTES + 100` bytes, asserts the caller gets an error (not a truncated password).
- `at_size_limit_succeeds` — writes exactly `MAX_FILE_BYTES` bytes (`"x\n"` + filler), asserts `"x"` is returned. Exercises the `take(MAX + 1)` path returning exactly `MAX`.
- `bom_is_stripped` — writes `\xef\xbb\xbfpassword\n`, asserts `"password"`.
- `bom_only_at_start` — writes `password\xef\xbb\xbf\n`, asserts the mid-buffer BOM bytes are preserved in the returned password.

Pre-existing tests (13) still pass: `reads_correctly_permissioned_file`, `strips_lf`, `strips_crlf`, `ignores_content_past_first_newline`, `accepts_no_trailing_newline`, `rejects_world_readable`, `rejects_group_readable`, `rejects_missing_file`, `rejects_directory`, `accepts_symlink_to_mode_0600_file`, `expand_tilde_absolute_untouched`, `expand_tilde_relative_untouched`, `expand_tilde_prefix`.

## Verification

- `cargo build` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (PR #38 CI gate).
- `cargo test --release password_file` — 17 passed, 0 failed (round 1); 20 passed, 0 failed (round 2).

## Non-goals honored

- No new dependencies.
- No refactor of `read_password_file_inner` beyond the two fixes.
- No changes to any other file under `src/commands/` besides `skill.rs` documentation.
- No changes to the encryption/decryption code (PR #34 territory).

## Round 2 (commit `871e262`)

Barbarian returned REQUEST CHANGES with two LOW findings. Both addressed here; no rebase, no amend.

### LOW-1: BOM-only file previously reached argon2 with an empty password

A file containing only `\xef\xbb\xbf`, only `\xef\xbb\xbf\n`, or zero bytes previously returned `Ok("")` from `read_password_file`, handing argon2 a zero-length secret and deriving a deterministic, attacker-known key. The round-1 BOM-drain path made this newly reachable via BOM-only input; the pre-existing empty-file case was buggy in the same way.

Fix: after the BOM drain and first-line extraction, reject `first_line.is_empty()` with `BttError::invalid_input` naming the offending path. The error message contains the string `"empty"` so tests and users can grep for it.

New tests:
- `bom_only_file_errors` — writes exactly `\xef\xbb\xbf`, asserts error contains `"empty"` or `"BOM"`.
- `bom_then_newline_only_errors` — writes `\xef\xbb\xbf\n`, asserts error contains `"empty"` or `"BOM"`.
- `empty_file_errors` — writes zero bytes, pins the behavior for the pre-existing case.

### LOW-2: `exceeds` branch was masked in `oversize_file_errors`

The `oversize_file_errors` test accepted either `"larger than"` or `"exceeds"` in the error message, masking that only the metadata-time advisory gate was exercised (the file is oversize at stat time, so the `md.len() > MAX_FILE_BYTES` check fires first). The read-time `exceeds` branch is reachable only if the file grows between `metadata()` and `read_to_end()`, which is not achievable from a unit test in safe Rust without wrapping the reader in a custom `Read` impl (scope creep — would require refactoring `read_password_file_inner` to accept a `Read`).

Fix:
- Tightened `oversize_file_errors` to assert specifically `"larger than"` and documented it as exercising the metadata-time check.
- Added a comment block on the read-time `if buf.len() as u64 > MAX_FILE_BYTES` branch explaining it is TOCTOU defense-in-depth, unit-test-unreachable in safe Rust, and that the property it enforces is guaranteed by `Read::take(MAX_FILE_BYTES + 1)` regardless.

### Cosmetic

- Dropped the dead `.min(MAX_FILE_BYTES)` on the buffer-capacity computation. The advisory gate above already rejects `md.len() > MAX_FILE_BYTES`, so `md.len()` is already bounded and the `.min()` was redundant.
- Documented the single-BOM-strip behavior: a file beginning with `\xef\xbb\xbf\xef\xbb\xbf` keeps the second BOM as part of the password. PowerShell never emits a double BOM, and eating arbitrary numbers of leading BOMs would let a crafted file coerce multiple distinct byte sequences into the same derived key.

### Round 2 verification

- `cargo build` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --release password_file` — **20 passed, 0 failed** (17 from round 1 + 3 new).
