### PR TITLE
[cryptid] password_file + btcli-compat: workflow path filter + tilde test refactor (#14)

### DIFF
--- a/.github/workflows/btcli-compat.yml
+++ b/.github/workflows/btcli-compat.yml
@@ -9,6 +9,12 @@ on:
     paths:
       - "src/commands/wallet_keys.rs"
       - "src/commands/password_file.rs"
+      # main.rs and cli.rs added per #14 NEW-L1: a future PR that
+      # rewires --password-file via the dispatch helper or the flag
+      # declaration without touching wallet_keys.rs / password_file.rs
+      # would otherwise silently skip this verifier.
+      - "src/main.rs"
+      - "src/cli.rs"
       - "Cargo.toml"
       - "Cargo.lock"
       - "scripts/btcli-compat/**"

--- a/src/commands/password_file.rs
+++ b/src/commands/password_file.rs
@@ -43,19 +43,25 @@ use zeroize::Zeroizing;
 
 use crate::error::BttError;
 
-/// Resolve `~` prefixes and `~user`-less tilde expansion using `$HOME`.
+/// Resolve `~` prefixes and `~user`-less tilde expansion against the
+/// caller-supplied home directory.
 ///
 /// We deliberately do NOT do arbitrary shell expansion — no `$VAR`
 /// substitution, no glob, no `..` magic. A password file path is supposed to
 /// be a concrete on-disk location.
-fn expand_tilde(path: &str) -> PathBuf {
+///
+/// `home` is taken as a parameter (rather than read from `std::env::var`
+/// internally) so tests can supply a synthetic value without mutating the
+/// process-global env. `std::env::set_var` becomes `unsafe` in Rust 1.82+
+/// and is a parallel-test footgun even before that — see issue #14 NEW-L2.
+fn expand_tilde(path: &str, home: Option<&str>) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
-        if let Ok(home) = std::env::var("HOME") {
+        if let Some(home) = home {
             return PathBuf::from(home).join(rest);
         }
     }
     if path == "~" {
-        if let Ok(home) = std::env::var("HOME") {
+        if let Some(home) = home {
             return PathBuf::from(home);
         }
     }
@@ -68,7 +74,8 @@ fn expand_tilde(path: &str) -> PathBuf {
 /// other-readable. The first line (stripped of trailing `\n` or `\r\n`) is
 /// returned as the password.
 pub fn read_password_file(path: &str) -> Result<Zeroizing<String>, BttError> {
-    let resolved = expand_tilde(path);
+    let home = std::env::var("HOME").ok();
+    let resolved = expand_tilde(path, home.as_deref());
     read_password_file_inner(&resolved)
 }
 
@@ -484,20 +491,43 @@ mod tests {
 
     #[test]
     fn expand_tilde_absolute_untouched() {
-        let p = expand_tilde("/tmp/foo");
+        let p = expand_tilde("/tmp/foo", Some("/home/alice"));
+        assert_eq!(p, PathBuf::from("/tmp/foo"));
+        let p = expand_tilde("/tmp/foo", None);
         assert_eq!(p, PathBuf::from("/tmp/foo"));
     }
 
     #[test]
     fn expand_tilde_relative_untouched() {
-        let p = expand_tilde("foo/bar");
+        // A relative path with no leading tilde is passed through unchanged
+        // regardless of the home value.
+        let p = expand_tilde("foo/bar", Some("/home/alice"));
+        assert_eq!(p, PathBuf::from("foo/bar"));
+        let p = expand_tilde("foo/bar", None);
         assert_eq!(p, PathBuf::from("foo/bar"));
     }
 
     #[test]
     fn expand_tilde_prefix() {
-        std::env::set_var("HOME", "/home/alice");
-        let p = expand_tilde("~/foo");
+        // No std::env::set_var here — the home directory is passed in.
+        let p = expand_tilde("~/foo", Some("/home/alice"));
         assert_eq!(p, PathBuf::from("/home/alice/foo"));
+    }
+
+    #[test]
+    fn expand_tilde_bare() {
+        let p = expand_tilde("~", Some("/home/alice"));
+        assert_eq!(p, PathBuf::from("/home/alice"));
+    }
+
+    #[test]
+    fn expand_tilde_no_home_returns_unchanged() {
+        // When HOME is unset, a tilde path has no expansion target and is
+        // passed through unchanged. Caller-side error handling is expected
+        // to detect the "~/foo" → "~/foo" no-op and surface it.
+        let p = expand_tilde("~/foo", None);
+        assert_eq!(p, PathBuf::from("~/foo"));
+        let p = expand_tilde("~", None);
+        assert_eq!(p, PathBuf::from("~"));
     }
 }


### PR DESCRIPTION
[cryptid]

Closes #14.

## Summary

Two LOW findings from issue #14, both small. None individually warranted a builder dispatch.

### NEW-L1: workflow path filter omitted \`src/main.rs\` and \`src/cli.rs\`

The btcli-compat verifier triggers on changes to \`wallet_keys.rs\` and \`password_file.rs\` but not on \`src/main.rs\` (the dispatch helper) or \`src/cli.rs\` (the flag declaration). A future PR that rewires \`--password-file\` via either of those without touching the named files would silently skip the verifier. Both files added to the paths list with an inline comment explaining the addition.

### NEW-L2: \`std::env::set_var\` in \`expand_tilde_prefix\` test

The \`expand_tilde()\` helper read \`\$HOME\` via \`std::env::var\`. Its \`expand_tilde_prefix\` test mutated \`\$HOME\` via \`std::env::set_var\`, which is a parallel-test footgun (the env mutation races with any other test that reads \$HOME, and \`std::env::set_var\` becomes \`unsafe\` in Rust 1.82+).

**Refactor**: \`expand_tilde()\` now takes \`home: Option<&str>\` as a parameter. The single production caller (\`read_password_file\`) reads \$HOME once and passes it in. Tests pass synthetic values directly with no env mutation.

### NEW-L3: \`fs::metadata\` follows symlinks

Already moot post PR #21. The file open path uses portable \`std::fs::File::open\` which follows symlinks, then \`file.metadata()\` is fd-based and reflects the opened (target) file. The FIFO check fires on the target, which is the correct semantic. **No code change needed.**

### NEW-I1: \`dtolnay/rust-toolchain\` SHA pin

Future-work note. PR #38 (toolchain pinning) addressed the floating-stable problem with a version pin; SHA pinning is a further improvement nobody is asking for yet. **No code change.**

## Files changed

- \`.github/workflows/btcli-compat.yml\` — paths list + comment, +6 / −0
- \`src/commands/password_file.rs\` — \`expand_tilde\` signature change + caller update + 5 tests, +39 / −9

Net: 2 files, +45 / −9. **No source code behavior change beyond the test surface. No new dependencies.**

## Tests

- \`expand_tilde_absolute_untouched\` updated to take \`None\` and \`Some\` variants (no behavior change)
- \`expand_tilde_relative_untouched\` updated likewise
- \`expand_tilde_prefix\` uses \`Some(\"/home/alice\")\`, no env mutation
- \`expand_tilde_bare\` **new** — covers the bare \`~\` case (previously untested)
- \`expand_tilde_no_home_returns_unchanged\` **new** — covers the \`None\` case for both \`~/foo\` and \`~\`

Result: **22 \`password_file\` tests** (was 20, +2 new), all passing.

## Verification (cryptid host)

- yaml parse on \`btcli-compat.yml\`: ok
- \`cargo build\`: clean
- \`cargo clippy --all-targets --all-features -- -D warnings\`: clean
- \`cargo test --release password_file\`: 22 passed, 0 failed

## Builder context

Hand-written by cryptid (not a builder subagent) because the diff is two small surgical changes — a 6-line YAML addition and a function signature refactor with mechanical caller/test updates.

## Out of scope

- NEW-L3 / NEW-I1 (no-op per above).
- SHA pinning the toolchain (separate decision, low value vs the version pin already in place).

## Related

- PR #21 (the password_file TOCTOU rewrite that made NEW-L3 moot).
- PR #38 (the toolchain version pin).