### PR TITLE
[cryptid] test(wallet): assert byte-preservation in regen-coldkey/regen-hotkey refusal (#20)

### DIFF
--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -2431,16 +2431,29 @@ mod tests {
         let (tmp, original) = seat_home("rc-refuse");
 
         let first = new_coldkey("w", 12, "pw", false).expect("first create");
-        // Use the freshly generated mnemonic to drive regen; we don't care
-        // about the identity it produces, only that regen refuses.
+        // Snapshot the on-disk coldkey BEFORE the second call so we can
+        // assert byte-for-byte preservation across the refusal — the
+        // load-bearing "guard is non-destructive" assertion that #20
+        // observed was missing on the regen side. (Symmetric with the
+        // new_coldkey_no_flag_existing_file_errors check.)
+        let coldkey_path = test_wallets_parent(&tmp).join("w").join("coldkey");
+        let coldkey_before = std::fs::read(&coldkey_path).expect("read coldkey");
+
         let phrase = first.mnemonic.clone();
         let second = regen_coldkey("w", Some(&phrase), None, "pw", false);
+
+        // Re-read after the call to compare byte-for-byte.
+        let coldkey_after = std::fs::read(&coldkey_path).expect("re-read coldkey");
 
         restore_home(tmp, original);
         let err = unwrap_err(second, "existing coldkey + no force (regen)");
         let msg = format!("{err:?}");
         assert!(msg.contains("coldkey"), "error should mention coldkey: {msg}");
         assert!(msg.contains("--force"), "error should mention --force: {msg}");
+        assert_eq!(
+            coldkey_before, coldkey_after,
+            "regen-coldkey refusal must not modify the existing coldkey file"
+        );
     }
 
     #[test]
@@ -2485,13 +2498,32 @@ mod tests {
 
         let _cr = new_coldkey("w", 12, "pw", false).expect("bootstrap coldkey");
         let first = new_hotkey("w", "default", 12, false).expect("first hotkey");
+
+        // Snapshot the on-disk hotkey BEFORE the second call so we can
+        // assert byte-for-byte preservation across the refusal — the
+        // load-bearing "guard is non-destructive" assertion that #20
+        // observed was missing on the regen side. (Symmetric with the
+        // new_hotkey_no_flag_existing_file_errors check.)
+        let hotkey_path = test_wallets_parent(&tmp)
+            .join("w")
+            .join("hotkeys")
+            .join("default");
+        let hotkey_before = std::fs::read(&hotkey_path).expect("read hotkey");
+
         let second = regen_hotkey("w", "default", Some(&first.mnemonic), None, false);
+
+        // Re-read after the call to compare byte-for-byte.
+        let hotkey_after = std::fs::read(&hotkey_path).expect("re-read hotkey");
 
         restore_home(tmp, original);
         let err = unwrap_err(second, "existing hotkey + no force (regen)");
         let msg = format!("{err:?}");
         assert!(msg.contains("hotkey"), "error should mention hotkey: {msg}");
         assert!(msg.contains("--force"), "error should mention --force: {msg}");
+        assert_eq!(
+            hotkey_before, hotkey_after,
+            "regen-hotkey refusal must not modify the existing hotkey file"
+        );
     }
 
     #[test]


### PR DESCRIPTION
[cryptid]

Closes #20.

## Summary

PR #18 added 11 tests for the new \`--force\` flag. Two of them (\`new_coldkey\` and \`new_hotkey\` refusal) asserted that after a refused call, the on-disk key file is byte-identical to its prior state — the load-bearing \"guard is non-destructive\" assertion that catches a future refactor accidentally writing before the guard fires.

The corresponding \`regen_coldkey\` and \`regen_hotkey\` refusal tests only asserted that the function returned an error. They did not check the file is unchanged. The PR #18 round-1 barbarian flagged this as the single LOW finding; it became issue #20.

## Fix

This PR makes the regen tests symmetric with the \`new_*\` tests. Both \`regen_coldkey_no_flag_existing_file_errors\` and \`regen_hotkey_no_flag_existing_file_errors\` now:

1. Snapshot the on-disk key bytes BEFORE the second call.
2. Take the (refused) call.
3. Re-read the file AFTER.
4. Assert \`pre == post\` byte-for-byte.

The error-message assertions are unchanged.

## Files changed

- \`src/commands/wallet_keys.rs\` — +34 / −2

**Test-only.** No production code touched. No new dependencies.

## Note on path resolution

Both new code paths use \`test_wallets_parent(&tmp)\` to resolve the wallet dir (not a hardcoded \`\$HOME/.bittensor\` path), which would have been wrong post PR #36 (the OS-dependent paths refactor). I caught this on the first \`cargo test\` run — the tests panicked with NotFound because they were reading from \`.bittensor/\` instead of \`.config/btt/\` — and switched to \`test_wallets_parent\` before committing.

## Verification

cryptid host:

- \`cargo build\`: clean
- \`cargo clippy --all-targets --all-features -- -D warnings\`: clean
- \`cargo test --release wallet_keys::tests::regen\`: **7/7 passed**

## Builder context

Hand-written by cryptid (not a builder subagent) — pure test addition, ~30 lines.

## Related

- PR #18 (the \`--force\` work that established the \`new_*\` byte-preservation pattern)
- PR #36 (the OS-dependent path refactor that made the hardcoded \`.bittensor\` path wrong)