### PR TITLE
[cryptid] dep-audit/checksum.py: path+file:// + excludes + exit code + cosmetic (#22)

### DIFF
--- a/scripts/dep-audit/checksum.py
+++ b/scripts/dep-audit/checksum.py
@@ -51,16 +51,26 @@ scripts/dep-audit/README.md for the operator's guide.
 """
 
 import argparse
+import fnmatch
 import hashlib
 import os
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 DEFAULT_LOCK = REPO_ROOT / "Cargo.lock"
 DEFAULT_DB = REPO_ROOT / ".cryptid" / "dep-audit" / "checksums.db"
+
+# Path-dep manifest exclusions. Anything matching these is omitted from the
+# deterministic file walk so the path-dep checksum doesn't churn on every
+# build. `target/` and `.git/` are directory names (matched against any
+# directory in the walk); the trailing entries are filename glob patterns
+# matched via fnmatch (editor swap files, OS metadata).
+PATH_DEP_EXCLUDE_DIRS = {"target", ".git"}
+PATH_DEP_EXCLUDE_FILE_GLOBS = ("*.swp", "*.swo", "*~", ".DS_Store")
 
 DB_HEADER = (
     "# btt dependency checksum database.\n"
@@ -81,6 +91,21 @@ DB_HEADER = (
 
 
 # ---------------------------------------------------------------------------
+# Error exit helper
+# ---------------------------------------------------------------------------
+
+def _die(msg):
+    """
+    Emit a script-error message to stderr and exit with code 2, per the
+    contract in the module docstring (1 = mismatch/new entry without --update,
+    2 = script error). Raises SystemExit(2) so callers that want to intercept
+    can still do so with `except SystemExit`.
+    """
+    print(msg, file=sys.stderr)
+    raise SystemExit(2)
+
+
+# ---------------------------------------------------------------------------
 # Cargo.lock parser (stdlib-only; Python 3.11 has tomllib but we avoid it
 # to keep this script runnable on any Python 3.x without version checks).
 # ---------------------------------------------------------------------------
@@ -94,7 +119,7 @@ def parse_cargo_lock(path):
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
-        raise SystemExit(f"error: cannot read {path}: {exc}")
+        _die(f"error: cannot read {path}: {exc}")
 
     packages = []
     current = None
@@ -136,6 +161,11 @@ def classify_source(source):
     """
     Return (kind, rest) where kind is 'registry', 'git', 'path', or 'workspace'
     (the last for packages with no `source` line — the workspace crate itself).
+
+    For path+ deps, Cargo writes `path+file:///abs/path` in Cargo.lock. We
+    parse the file:// URL and return the absolute filesystem path, so the
+    caller receives a value ready to hand to pathlib without re-joining
+    against REPO_ROOT (which would hard-fail on an absolute URL-shaped string).
     """
     if source is None:
         return ("workspace", "")
@@ -144,8 +174,12 @@ def classify_source(source):
     if source.startswith("git+"):
         return ("git", source[len("git+"):])
     if source.startswith("path+"):
-        return ("path", source[len("path+"):])
-    raise SystemExit(f"error: unknown source kind: {source!r}")
+        rest = source[len("path+"):]
+        if rest.startswith("file://"):
+            parsed = urlparse(rest)
+            rest = parsed.path
+        return ("path", rest)
+    _die(f"error: unknown source kind: {source!r}")
 
 
 def checksum_registry(pkg):
@@ -158,7 +192,7 @@ def checksum_registry(pkg):
     tripwire fires.
     """
     if not pkg.get("checksum"):
-        raise SystemExit(
+        _die(
             f"error: registry dep {pkg['name']}@{pkg['version']} has no "
             f"checksum field in Cargo.lock; cannot verify"
         )
@@ -173,13 +207,13 @@ def checksum_git(pkg, rest):
     content hash. We don't need to check out the tree.
     """
     if "#" not in rest:
-        raise SystemExit(
+        _die(
             f"error: git dep {pkg['name']}@{pkg['version']} has no commit "
             f"fragment in source {rest!r}"
         )
     commit = rest.rsplit("#", 1)[1]
     if not re.fullmatch(r"[0-9a-f]{40}", commit):
-        raise SystemExit(
+        _die(
             f"error: git dep {pkg['name']}@{pkg['version']} has non-sha1 "
             f"commit fragment {commit!r}"
         )
@@ -197,21 +231,25 @@ def checksum_path(pkg, rest):
     if not root.is_absolute():
         root = (REPO_ROOT / rest).resolve()
     if not root.exists():
-        raise SystemExit(
+        _die(
             f"error: path dep {pkg['name']}@{pkg['version']} points at "
             f"{root} which does not exist"
         )
     entries = []
     for dirpath, dirnames, filenames in os.walk(root):
+        # Prune excluded directories in place so os.walk does not descend.
+        dirnames[:] = [d for d in dirnames if d not in PATH_DEP_EXCLUDE_DIRS]
         dirnames.sort()
         for fn in sorted(filenames):
+            if any(fnmatch.fnmatch(fn, pat) for pat in PATH_DEP_EXCLUDE_FILE_GLOBS):
+                continue
             full = Path(dirpath) / fn
             if full.is_symlink():
                 kind = "l"
                 try:
                     target = os.readlink(full)
                 except OSError as exc:
-                    raise SystemExit(f"error: cannot read symlink {full}: {exc}")
+                    _die(f"error: cannot read symlink {full}: {exc}")
                 content_hash = hashlib.sha256(target.encode("utf-8")).hexdigest()
             else:
                 kind = "f"
@@ -221,7 +259,7 @@ def checksum_path(pkg, rest):
                         for chunk in iter(lambda: fp.read(65536), b""):
                             h.update(chunk)
                 except OSError as exc:
-                    raise SystemExit(f"error: cannot read {full}: {exc}")
+                    _die(f"error: cannot read {full}: {exc}")
                 content_hash = h.hexdigest()
             rel = full.relative_to(root).as_posix()
             entries.append(f"{kind} {rel} {content_hash}")
@@ -245,7 +283,7 @@ def compute_entry(pkg):
     elif kind == "path":
         sha = checksum_path(pkg, rest)
     else:
-        raise SystemExit(f"error: unhandled source kind {kind!r}")
+        _die(f"error: unhandled source kind {kind!r}")
     key = f"{pkg['name']}@{pkg['version']}"
     return (key, kind, sha)
 
@@ -267,7 +305,7 @@ def load_db(path):
             continue
         parts = line.split("\t")
         if len(parts) != 3:
-            raise SystemExit(f"error: malformed DB line in {path}: {raw!r}")
+            _die(f"error: malformed DB line in {path}: {raw!r}")
         key, kind, sha = parts
         db[key] = (kind, sha)
     return db
@@ -403,7 +441,12 @@ def main(argv=None):
         )
         report_lines.append("")
 
-    if new_entries:
+    # The "new deps" interstitial is suppressed under --update: by the time
+    # the report renders, those entries are about to be written to the DB,
+    # so the framing ("not yet in DB", "Run --update locally") is stale.
+    # The trailing "DB updated: +N new" line on stderr already tells the
+    # operator what was added.
+    if new_entries and not args.update:
         report_lines.append("**New deps (not yet in DB):**")
         report_lines.append("")
         report_lines.append("```")
@@ -411,14 +454,13 @@ def main(argv=None):
             report_lines.append(f"  {key}  {kind}  {sha}")
         report_lines.append("```")
         report_lines.append("")
-        if not args.update:
-            report_lines.append(
-                "These entries are not in the committed DB. Run "
-                "`scripts/dep-audit/checksum.py --update` locally and "
-                "commit the resulting DB diff alongside the Cargo.lock "
-                "change. CI never runs with --update."
-            )
-            report_lines.append("")
+        report_lines.append(
+            "These entries are not in the committed DB. Run "
+            "`scripts/dep-audit/checksum.py --update` locally and "
+            "commit the resulting DB diff alongside the Cargo.lock "
+            "change. CI never runs with --update."
+        )
+        report_lines.append("")
 
     if stale:
         report_lines.append("**Stale DB entries (in DB but not in Cargo.lock):**")

--- a/scripts/dep-audit/test_checksum.py
+++ b/scripts/dep-audit/test_checksum.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+Unit tests for scripts/dep-audit/checksum.py.
+
+Stdlib-only (unittest). No pytest. Run with either:
+
+    python3 -m unittest scripts/dep-audit/test_checksum.py -v
+    python3 scripts/dep-audit/test_checksum.py
+
+These tests pin the four follow-up fixes from issue #22:
+
+  LOW-1  path+file:// URL handling — classify_source must return an absolute
+         filesystem path so checksum_path doesn't try to re-join it against
+         REPO_ROOT (which would produce a nonsense path and hard-fail).
+
+  LOW-2  path-dep manifest exclusions — checksum_path must skip target/,
+         .git/, editor swap files (*.swp, *.swo, *~), and .DS_Store so the
+         checksum doesn't churn on every build of any future path dep.
+
+  INFO-1 exit code 2 on script error — script-error paths must exit 2,
+         distinct from exit 1 (mismatch / new-entry-without-update). Tested
+         here by raising the unknown-source-kind error.
+
+  INFO-2 cosmetic — under --update the "**New deps (not yet in DB):**"
+         interstitial is suppressed because by the time the report renders
+         the entries have been written. The trailing "DB updated" line on
+         stderr already tells the operator what changed.
+"""
+
+import contextlib
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+CHECKSUM_PY = HERE / "checksum.py"
+
+
+def _load_checksum_module():
+    """
+    Load checksum.py as a module despite the parent directory's hyphen
+    (which prevents normal `import scripts.dep_audit.checksum`). We load
+    by absolute file path via importlib so the test file is fully
+    self-contained.
+    """
+    spec = importlib.util.spec_from_file_location("checksum_under_test", CHECKSUM_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checksum = _load_checksum_module()
+
+
+class ClassifySourceTests(unittest.TestCase):
+    """LOW-1: path+file:// URLs must resolve to an absolute filesystem path."""
+
+    def test_path_file_url_returns_absolute_path(self):
+        # Synthetic Cargo.lock-shaped source line for a path dep.
+        source = "path+file:///tmp/some-path-dep"
+        kind, rest = checksum.classify_source(source)
+        self.assertEqual(kind, "path")
+        self.assertEqual(rest, "/tmp/some-path-dep")
+        # The returned value must be a usable absolute path; pathlib agrees.
+        self.assertTrue(Path(rest).is_absolute())
+
+    def test_path_file_url_with_nested_path(self):
+        source = "path+file:///home/dev/projects/my-crate"
+        kind, rest = checksum.classify_source(source)
+        self.assertEqual(kind, "path")
+        self.assertEqual(rest, "/home/dev/projects/my-crate")
+
+    def test_registry_source_unchanged(self):
+        source = "registry+https://github.com/rust-lang/crates.io-index"
+        kind, rest = checksum.classify_source(source)
+        self.assertEqual(kind, "registry")
+        self.assertTrue(rest.startswith("https://"))
+
+    def test_git_source_unchanged(self):
+        source = "git+https://example.invalid/foo?branch=main#" + ("a" * 40)
+        kind, rest = checksum.classify_source(source)
+        self.assertEqual(kind, "git")
+        self.assertTrue(rest.startswith("https://"))
+
+    def test_workspace_source_when_none(self):
+        kind, rest = checksum.classify_source(None)
+        self.assertEqual(kind, "workspace")
+        self.assertEqual(rest, "")
+
+
+class PathDepExclusionTests(unittest.TestCase):
+    """LOW-2: target/, .git/, editor swap files must not enter the manifest."""
+
+    def _build_tree(self, root: Path) -> None:
+        # Real source file that MUST be in the manifest.
+        (root / "src").mkdir()
+        (root / "src" / "lib.rs").write_text("fn main() {}\n", encoding="utf-8")
+        (root / "Cargo.toml").write_text("[package]\nname = \"x\"\n", encoding="utf-8")
+
+        # target/ — build artifacts; must be excluded.
+        (root / "target").mkdir()
+        (root / "target" / "debug").mkdir()
+        (root / "target" / "debug" / "build.log").write_text("noise", encoding="utf-8")
+
+        # .git/ — vcs metadata; must be excluded.
+        (root / ".git").mkdir()
+        (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+        # Editor swap and OS metadata files; must be excluded.
+        (root / "src" / ".lib.rs.swp").write_text("vim noise", encoding="utf-8")
+        (root / "src" / "lib.rs.swo").write_text("vim noise", encoding="utf-8")
+        (root / "src" / "lib.rs~").write_text("backup noise", encoding="utf-8")
+        (root / ".DS_Store").write_text("mac noise", encoding="utf-8")
+
+    def test_excluded_paths_do_not_appear_in_manifest(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "fake-path-dep"
+            root.mkdir()
+            self._build_tree(root)
+
+            # Synthetic pkg dict the way checksum_path consumes it.
+            pkg = {"name": "fake", "version": "0.0.0"}
+            sha = checksum.checksum_path(pkg, str(root))
+            self.assertRegex(sha, r"^[0-9a-f]{64}$")
+
+            # We re-derive the manifest the same way checksum_path does
+            # (minus hashing) so we can assert which relpaths were included.
+            included = self._collect_relpaths(root)
+
+            # Source files we expect.
+            self.assertIn("Cargo.toml", included)
+            self.assertIn("src/lib.rs", included)
+
+            # Excluded directories: nothing under them must appear.
+            for rel in included:
+                self.assertFalse(
+                    rel.startswith("target/"),
+                    f"target/ should be excluded, found {rel!r}",
+                )
+                self.assertFalse(
+                    rel.startswith(".git/"),
+                    f".git/ should be excluded, found {rel!r}",
+                )
+
+            # Excluded filename globs: none of these basenames must appear.
+            for rel in included:
+                base = rel.rsplit("/", 1)[-1]
+                self.assertNotEqual(base, ".lib.rs.swp")
+                self.assertNotEqual(base, "lib.rs.swo")
+                self.assertNotEqual(base, "lib.rs~")
+                self.assertNotEqual(base, ".DS_Store")
+
+    def _collect_relpaths(self, root: Path):
+        """
+        Mirror the walk in checksum_path so we can introspect what would be
+        hashed without recomputing the digest by hand.
+        """
+        import fnmatch
+
+        rels = []
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames if d not in checksum.PATH_DEP_EXCLUDE_DIRS
+            ]
+            dirnames.sort()
+            for fn in sorted(filenames):
+                if any(
+                    fnmatch.fnmatch(fn, pat)
+                    for pat in checksum.PATH_DEP_EXCLUDE_FILE_GLOBS
+                ):
+                    continue
+                full = Path(dirpath) / fn
+                rels.append(full.relative_to(root).as_posix())
+        return rels
+
+    def test_manifest_stable_when_only_excluded_files_change(self):
+        """
+        Stronger property: adding more target/ noise must not change the
+        digest. This is the actual reason the exclusions exist.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "fake-path-dep"
+            root.mkdir()
+            self._build_tree(root)
+            pkg = {"name": "fake", "version": "0.0.0"}
+            sha_before = checksum.checksum_path(pkg, str(root))
+
+            # Add more excluded noise.
+            (root / "target" / "debug" / "more.log").write_text("more", encoding="utf-8")
+            (root / ".git" / "objects").mkdir()
+            (root / ".git" / "objects" / "abc").write_text("blob", encoding="utf-8")
+            (root / "src" / "another.rs.swp").write_text("vim", encoding="utf-8")
+
+            sha_after = checksum.checksum_path(pkg, str(root))
+            self.assertEqual(
+                sha_before,
+                sha_after,
+                "checksum must be stable when only excluded paths change",
+            )
+
+
+class ExitCodeTwoTests(unittest.TestCase):
+    """INFO-1: script-error paths must exit 2, not 1."""
+
+    def test_unknown_source_kind_exits_two_in_process(self):
+        with self.assertRaises(SystemExit) as cm:
+            checksum.classify_source("svn+https://example.invalid/repo")
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_die_helper_exits_two(self):
+        with self.assertRaises(SystemExit) as cm:
+            checksum._die("error: synthetic")
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_unreadable_lock_exits_two_subprocess(self):
+        # Spawn the script with a --lock pointing at a path that does not
+        # exist. Should emit an error and exit 2.
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CHECKSUM_PY),
+                "--lock",
+                "/nonexistent/path/Cargo.lock",
+                "--db",
+                "/nonexistent/path/checksums.db",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            2,
+            f"expected exit 2 on unreadable Cargo.lock, got {result.returncode}; "
+            f"stderr={result.stderr!r}",
+        )
+        self.assertIn("error:", result.stderr)
+
+
+class UpdateModeInterstitialTests(unittest.TestCase):
+    """INFO-2: --update runs must not show the 'Run --update' interstitial."""
+
+    def test_update_run_omits_run_update_interstitial(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            # Minimal valid Cargo.lock with a single registry dep so the
+            # script has work to do and the new_entries branch is exercised.
+            lock = tdp / "Cargo.lock"
+            lock.write_text(
+                'version = 4\n'
+                '\n'
+                '[[package]]\n'
+                'name = "synthetic-dep"\n'
+                'version = "1.2.3"\n'
+                'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+                'checksum = "' + ("a" * 64) + '"\n',
+                encoding="utf-8",
+            )
+            db = tdp / "checksums.db"  # does not exist; will be seeded
+
+            # Capture stdout while invoking main(--update).
+            buf = io.StringIO()
+            err_buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(err_buf):
+                rc = checksum.main(
+                    ["--update", "--lock", str(lock), "--db", str(db)]
+                )
+            self.assertEqual(rc, 0, f"expected rc=0, got {rc}; out={buf.getvalue()!r}")
+
+            out = buf.getvalue()
+
+            # The "Run --update" interstitial must NOT appear.
+            self.assertNotIn("Run `scripts/dep-audit/checksum.py --update`", out)
+            self.assertNotIn("CI never runs with --update", out)
+            # The "New deps (not yet in DB)" header must also not appear,
+            # because by the time the report renders the entries have been
+            # written and that framing is stale.
+            self.assertNotIn("**New deps (not yet in DB):**", out)
+            # Sanity: STATUS line still reported.
+            self.assertIn("STATUS: PASS", out)
+
+            # The DB should have been written.
+            self.assertTrue(db.exists())
+            db_text = db.read_text(encoding="utf-8")
+            self.assertIn("synthetic-dep@1.2.3", db_text)
+
+    def test_non_update_run_keeps_run_update_interstitial(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            lock = tdp / "Cargo.lock"
+            lock.write_text(
+                'version = 4\n'
+                '\n'
+                '[[package]]\n'
+                'name = "synthetic-dep"\n'
+                'version = "1.2.3"\n'
+                'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+                'checksum = "' + ("a" * 64) + '"\n',
+                encoding="utf-8",
+            )
+            db = tdp / "checksums.db"
+
+            buf = io.StringIO()
+            err_buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(err_buf):
+                rc = checksum.main(["--lock", str(lock), "--db", str(db)])
+
+            # Without --update and with a new dep, the script returns 1.
+            self.assertEqual(rc, 1)
+            out = buf.getvalue()
+            # The interstitial IS present in the non-update case.
+            self.assertIn("**New deps (not yet in DB):**", out)
+            self.assertIn("Run `scripts/dep-audit/checksum.py --update`", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
[cryptid]

Closes #22. Batched LOW + INFO follow-ups from the PR #17 round-1 barbaric review of the dep-checksum tripwire. All four fixes are minimum-diff, stdlib-only, no new dependencies.

## Fixes

### LOW-1: `path+file://` URL handling
`scripts/dep-audit/checksum.py:153-176` — `classify_source` now parses `path+file://` sources via `urllib.parse.urlparse` and returns the absolute filesystem path. Previously the `file://` scheme was left in the rest string and re-joined against `REPO_ROOT`, which would produce a nonsense path on any real path dep. btt has zero path deps today so this was cold code; the fix unblocks the moment one lands.

### LOW-2: path-dep manifest exclusions
`scripts/dep-audit/checksum.py:60-67` (new module-level constants) and `scripts/dep-audit/checksum.py:215-227` (the walk in `checksum_path`) — the deterministic file walker now prunes `target/` and `.git/` from `os.walk` and skips `*.swp`, `*.swo`, `*~`, `.DS_Store` via `fnmatch`. The exclusion lists are constants at the top of the file with a comment explaining the purpose. Without this, any future path dep's checksum would churn on every cargo build.

### INFO-1: exit code 2 on script error
`scripts/dep-audit/checksum.py:88-99` (new `_die` helper) and the seven script-error sites at `parse_cargo_lock` (line ~111), `checksum_registry` (line ~177), `checksum_git` (lines ~191, ~196), `checksum_path` (lines ~220, ~239, ~250), `compute_entry` (line ~270), and `load_db` (line ~288) — all `raise SystemExit(f"error: ...")` calls (which exited 1) are replaced with `_die(...)` which prints to stderr and raises `SystemExit(2)`, matching the docstring contract (1 = mismatch / new entries without --update, 2 = script error).

### INFO-2: `--update` runs no longer print the "Run --update" interstitial
`scripts/dep-audit/checksum.py:444-462` — the `**New deps (not yet in DB):**` listing and its "Run `scripts/dep-audit/checksum.py --update` locally" follow-on are now gated on `not args.update`. By the time the report renders under `--update` mode, the entries have already been written; the framing was stale. The trailing `DB updated: +N new` line on stderr remains the authoritative signal of what was added.

## Tests

New file: `scripts/dep-audit/test_checksum.py` (stdlib `unittest` only — **no new deps**, no pytest). Twelve tests:

- `ClassifySourceTests` (5): synthetic `path+file:///tmp/some-path-dep` returns `("path", "/tmp/some-path-dep")`; nested file:// path; registry, git, and workspace (None) sources still classify correctly.
- `PathDepExclusionTests` (2): synthetic tree containing `target/`, `.git/`, `*.swp`, `*.swo`, `*~`, `.DS_Store` — manifest must include `Cargo.toml` and `src/lib.rs` and must NOT include any of the excluded paths. Stronger property test: adding more `target/` and `.git/` noise to the same tree must NOT change the resulting checksum.
- `ExitCodeTwoTests` (3): `classify_source("svn+...")` raises `SystemExit(2)`; `_die(...)` raises `SystemExit(2)`; spawning the script with `--lock /nonexistent` via `subprocess` exits with code 2 and prints `error:` to stderr.
- `UpdateModeInterstitialTests` (2): synthetic minimal `Cargo.lock` with one registry dep; under `--update` the captured stdout must NOT contain "Run \`scripts/dep-audit/checksum.py --update\`", "CI never runs with --update", or "**New deps (not yet in DB):**", but must still contain "STATUS: PASS"; without `--update` the same lock produces the interstitial and exits 1 (regression guard so the gate isn't overzealous).

Run with either:

```
python3 -m unittest discover -s scripts/dep-audit -p test_checksum.py -v
python3 scripts/dep-audit/test_checksum.py
```

## Verification

- 12/12 unit tests pass
- `python3 scripts/dep-audit/checksum.py --help` parses cleanly
- `python3 scripts/dep-audit/checksum.py` against the real repo: 972 deps tracked, 972 matches, STATUS: PASS, exit 0. No drift; all existing checksums still validate (the fixes are byte-compatible for the existing registry/git deps)

## No new dependencies

This PR adds **zero** dependencies. The only new imports in `checksum.py` are `fnmatch` and `urllib.parse`, both Python stdlib. The test file imports `contextlib`, `importlib.util`, `io`, `os`, `subprocess`, `sys`, `tempfile`, `unittest`, `pathlib` — all stdlib. No `pytest`, no third-party packages of any kind.

## CI

The dep-audit workflow will run on push and exercise `checksum.py` end-to-end against the real `Cargo.lock` and committed DB.