### PR TITLE
[cryptid] paths.rs: batched follow-ups from PR #36 barbarian (#37)

### DIFF
--- a/src/commands/paths.rs
+++ b/src/commands/paths.rs
@@ -22,85 +22,167 @@
 //! warning telling them how to migrate. btt never silently moves wallet
 //! material on the user's behalf.
 
-use std::path::PathBuf;
+use std::env::VarError;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Once;
 
 use crate::error::BttError;
 
-/// Legacy wallet-root location used by btt prior to this module.
+/// Read an environment variable, distinguishing "not set" from "not UTF-8".
 ///
-/// This is the btcli-compatible path. It is only consulted as a fallback
-/// when the new OS-dependent config directory does not yet exist.
-fn legacy_dir() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    if home.is_empty() {
-        return None;
+/// Returns:
+/// - `Ok(Some(value))` if the variable is set and valid UTF-8.
+/// - `Ok(None)` if the variable is not present.
+/// - `Err(BttError)` if the variable is present but contains non-UTF-8 bytes.
+fn read_env_var(key: &str) -> Result<Option<String>, BttError> {
+    match std::env::var(key) {
+        Ok(v) => Ok(Some(v)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(_)) => Err(BttError::io(format!(
+            "{} contains non-UTF-8 bytes",
+            key
+        ))),
     }
-    Some(PathBuf::from(home).join(".bittensor"))
 }
 
-/// Compute the OS-native config directory without consulting the filesystem.
-fn native_config_dir() -> Result<PathBuf, BttError> {
+/// Compute the OS-native config directory from explicit env values.
+///
+/// This is the single source of truth for the per-OS resolver logic.
+/// Production callers go through [`config_dir`] / [`native_config_dir`],
+/// which read the process environment; tests (and the wallet_keys test
+/// helpers) can call this directly with synthetic values to avoid any
+/// `cfg(target_os)` branching of their own.
+///
+/// Inputs:
+/// - `home`: value of `$HOME`. Required on linux / macOS / BSDs.
+/// - `xdg`: value of `$XDG_CONFIG_HOME`. Consulted only on linux / BSDs.
+/// - `appdata`: value of `%APPDATA%`. Required on windows.
+///
+/// An `Some("")` empty-string input is treated as "not set" (matching the
+/// historical behavior of `native_config_dir`), so callers can pass raw
+/// env-var reads straight through.
+pub(crate) fn config_dir_from_env(
+    home: Option<&str>,
+    xdg: Option<&str>,
+    appdata: Option<&str>,
+) -> Result<PathBuf, BttError> {
     #[cfg(target_os = "linux")]
     {
-        if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-            if !xdg.is_empty() {
-                return Ok(PathBuf::from(xdg).join("btt"));
+        let _ = appdata;
+        if let Some(x) = xdg {
+            if !x.is_empty() {
+                return Ok(PathBuf::from(x).join("btt"));
             }
         }
-        let home = std::env::var("HOME")
-            .map_err(|_| BttError::io("HOME environment variable not set"))?;
-        Ok(PathBuf::from(home).join(".config").join("btt"))
+        let h = home
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| BttError::io("HOME environment variable not set"))?;
+        Ok(PathBuf::from(h).join(".config").join("btt"))
     }
     #[cfg(target_os = "macos")]
     {
-        let home = std::env::var("HOME")
-            .map_err(|_| BttError::io("HOME environment variable not set"))?;
-        Ok(PathBuf::from(home)
+        let _ = xdg;
+        let _ = appdata;
+        let h = home
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| BttError::io("HOME environment variable not set"))?;
+        Ok(PathBuf::from(h)
             .join("Library")
             .join("Application Support")
             .join("btt"))
     }
     #[cfg(target_os = "windows")]
     {
-        let appdata = std::env::var("APPDATA")
-            .map_err(|_| BttError::io("APPDATA environment variable not set"))?;
-        Ok(PathBuf::from(appdata).join("btt"))
+        let _ = home;
+        let _ = xdg;
+        let a = appdata
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| BttError::io("APPDATA environment variable not set"))?;
+        Ok(PathBuf::from(a).join("btt"))
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
+        let _ = appdata;
         // BSDs, Solaris, illumos, etc.: default to the XDG-style linux
         // layout. Users on exotic targets can set `XDG_CONFIG_HOME`
         // explicitly if they want a different location.
-        if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-            if !xdg.is_empty() {
-                return Ok(PathBuf::from(xdg).join("btt"));
+        if let Some(x) = xdg {
+            if !x.is_empty() {
+                return Ok(PathBuf::from(x).join("btt"));
             }
         }
-        let home = std::env::var("HOME")
-            .map_err(|_| BttError::io("HOME environment variable not set"))?;
-        Ok(PathBuf::from(home).join(".config").join("btt"))
+        let h = home
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| BttError::io("HOME environment variable not set"))?;
+        Ok(PathBuf::from(h).join(".config").join("btt"))
     }
+}
+
+/// Compute the OS-native config directory without consulting the filesystem.
+///
+/// Reads `HOME`, `XDG_CONFIG_HOME`, and `APPDATA` from the process
+/// environment and dispatches to [`config_dir_from_env`]. Returns distinct
+/// errors for non-UTF-8 env values so users see an actionable diagnostic.
+fn native_config_dir() -> Result<PathBuf, BttError> {
+    let home = read_env_var("HOME")?;
+    let xdg = read_env_var("XDG_CONFIG_HOME")?;
+    let appdata = read_env_var("APPDATA")?;
+    config_dir_from_env(home.as_deref(), xdg.as_deref(), appdata.as_deref())
+}
+
+/// Legacy wallet-root location used by btt prior to this module.
+///
+/// This is the btcli-compatible path. It is only consulted as a fallback
+/// when the new OS-dependent config directory does not yet exist.
+///
+/// Returns `Ok(None)` if `HOME` is unset or empty; `Err` only if `HOME` is
+/// present but non-UTF-8.
+fn legacy_dir() -> Result<Option<PathBuf>, BttError> {
+    let home = read_env_var("HOME")?;
+    Ok(home
+        .filter(|h| !h.is_empty())
+        .map(|h| PathBuf::from(h).join(".bittensor")))
 }
 
 // Emit the legacy-fallback warning at most once per process.
 static LEGACY_WARNING: Once = Once::new();
 
-fn warn_legacy(legacy: &std::path::Path, new: &std::path::Path) {
-    LEGACY_WARNING.call_once(|| {
-        eprintln!(
+/// Emit the legacy-fallback migration warning at most once per `once`.
+///
+/// Writer and `Once` are injected so tests can capture the output and
+/// supply a fresh `Once` per test (the static `LEGACY_WARNING` would
+/// otherwise "stick" across tests running in the same process).
+fn warn_legacy_to(
+    out: &mut dyn Write,
+    once: &Once,
+    legacy: &Path,
+    new: &Path,
+) {
+    once.call_once(|| {
+        let _ = writeln!(
+            out,
             "btt: legacy wallet directory at {} detected.",
             legacy.display()
         );
-        eprintln!(
+        let _ = writeln!(
+            out,
             "     Move it to {} to use the new location:",
             new.display()
         );
-        eprintln!("         mv {} {}", legacy.display(), new.display());
-        eprintln!(
+        let _ = writeln!(out, "         mv {} {}", legacy.display(), new.display());
+        let _ = writeln!(
+            out,
             "     btt will continue to use the legacy location until the move is performed."
         );
     });
+}
+
+/// Production-side wrapper: emit to stderr, gated by the process-wide
+/// `LEGACY_WARNING` `Once`.
+fn warn_legacy(legacy: &Path, new: &Path) {
+    let mut err = std::io::stderr().lock();
+    warn_legacy_to(&mut err, &LEGACY_WARNING, legacy, new);
 }
 
 /// Resolve the per-user btt config directory.
@@ -121,7 +203,7 @@ pub fn config_dir() -> Result<PathBuf, BttError> {
     }
 
     // Native path does not exist. Check for the legacy location.
-    if let Some(legacy) = legacy_dir() {
+    if let Some(legacy) = legacy_dir()? {
         if legacy.exists() {
             warn_legacy(&legacy, &native);
             return Ok(legacy);
@@ -153,16 +235,140 @@ pub fn wallet_dir(name: &str) -> Result<PathBuf, BttError> {
 #[cfg(test)]
 pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+// ── Test helpers (shared with other modules' tests) ──────────────────────
+
+/// Seat the config-dir env vars at `tmp` and return a guard that restores
+/// `HOME`, `XDG_CONFIG_HOME`, and `APPDATA` on drop.
+///
+/// Used by `wallet_keys::tests` and this module's own tests. The caller
+/// must hold [`ENV_LOCK`] for the duration of the guard's lifetime — env
+/// vars are process-global.
+///
+/// Returns `(guard, wallets_parent)` where `wallets_parent` is the exact
+/// path that [`wallets_dir`] will resolve to for this tmp root on the
+/// current OS. The caller can join `<name>` onto it to get a wallet dir.
+///
+/// The wallets parent is created on disk so [`config_dir`]'s
+/// legacy-fallback branch is never taken for this tmp.
+#[cfg(test)]
+pub(crate) fn seat_config_env_at(tmp: &Path) -> (EnvGuard, PathBuf) {
+    let guard = EnvGuard::seat_for(tmp);
+    let parent = wallets_parent_for(tmp);
+    std::fs::create_dir_all(&parent).expect("create wallets parent");
+    (guard, parent)
+}
+
+/// Compute the `wallets/` parent dir that [`config_dir`] will resolve to
+/// for a given test tmp root, on the current host OS.
+///
+/// Goes through [`config_dir_from_env`] so there is exactly one site that
+/// knows the per-OS resolver shape.
+#[cfg(test)]
+pub(crate) fn wallets_parent_for(tmp: &Path) -> PathBuf {
+    let (home, xdg, appdata) = synthetic_env_for(tmp);
+    config_dir_from_env(Some(&home), xdg.as_deref(), appdata.as_deref())
+        .expect("synthetic env resolves")
+        .join("wallets")
+}
+
+/// Compute the synthetic `(HOME, XDG_CONFIG_HOME, APPDATA)` triple that
+/// would resolve under `tmp`. On a given OS only one of the three is
+/// meaningful, but we return all three so callers can plug them straight
+/// into `std::env::set_var`.
+#[cfg(test)]
+fn synthetic_env_for(tmp: &Path) -> (String, Option<String>, Option<String>) {
+    let home = tmp.to_str().expect("tmp is UTF-8").to_string();
+    let xdg = Some(
+        tmp.join("xdg")
+            .to_str()
+            .expect("xdg path is UTF-8")
+            .to_string(),
+    );
+    let appdata = Some(
+        tmp.join("AppData")
+            .join("Roaming")
+            .to_str()
+            .expect("appdata path is UTF-8")
+            .to_string(),
+    );
+    (home, xdg, appdata)
+}
+
+/// Symmetric env-restoring guard for `HOME`, `XDG_CONFIG_HOME`, and
+/// `APPDATA`. Saves the original values of all three on construction and
+/// restores them on drop, regardless of which one(s) were actually mutated.
+///
+/// Used by both this module's tests and `wallet_keys::tests`, which is how
+/// we fix the old asymmetry where `seat_home_env` set both `HOME` and
+/// `XDG_CONFIG_HOME` but only `HOME` was ever restored.
+#[cfg(test)]
+pub(crate) struct EnvGuard {
+    home: Option<String>,
+    xdg: Option<String>,
+    appdata: Option<String>,
+}
+
+#[cfg(test)]
+impl EnvGuard {
+    /// Capture the current values of all three config env vars. Does not
+    /// mutate anything. Useful when a test wants to call arbitrary
+    /// `std::env::set_var` / `remove_var` directly and only needs a
+    /// drop-time restore.
+    pub(crate) fn capture() -> Self {
+        Self {
+            home: std::env::var("HOME").ok(),
+            xdg: std::env::var("XDG_CONFIG_HOME").ok(),
+            appdata: std::env::var("APPDATA").ok(),
+        }
+    }
+
+    /// Capture current values and then seat `HOME`, `XDG_CONFIG_HOME`,
+    /// and `APPDATA` at synthetic values under `tmp`. On drop, all three
+    /// are restored to their original values.
+    fn seat_for(tmp: &Path) -> Self {
+        let guard = Self::capture();
+        let (home, xdg, appdata) = synthetic_env_for(tmp);
+        std::env::set_var("HOME", &home);
+        if let Some(x) = xdg.as_deref() {
+            std::env::set_var("XDG_CONFIG_HOME", x);
+        }
+        if let Some(a) = appdata.as_deref() {
+            std::env::set_var("APPDATA", a);
+        }
+        guard
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match &self.xdg {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match &self.appdata {
+            Some(v) => std::env::set_var("APPDATA", v),
+            None => std::env::remove_var("APPDATA"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    struct EnvGuard {
+    /// One-off env guard that only touches a single key. Used by tests
+    /// that want to exercise the production env-reading path directly.
+    struct SingleEnvGuard {
         key: &'static str,
         original: Option<String>,
     }
 
-    impl EnvGuard {
+    impl SingleEnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let original = std::env::var(key).ok();
             std::env::set_var(key, value);
@@ -176,7 +382,7 @@ mod tests {
         }
     }
 
-    impl Drop for EnvGuard {
+    impl Drop for SingleEnvGuard {
         fn drop(&mut self) {
             match &self.original {
                 Some(v) => std::env::set_var(self.key, v),
@@ -185,11 +391,81 @@ mod tests {
         }
     }
 
+    // ── Item 4: resolver via synthetic values (no env mutation) ──────
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolver_linux_xdg_wins() {
+        let p = config_dir_from_env(
+            Some("/home/alice"),
+            Some("/xdg/root"),
+            None,
+        )
+        .expect("resolve");
+        assert_eq!(p, PathBuf::from("/xdg/root/btt"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolver_linux_empty_xdg_falls_back_to_home() {
+        let p = config_dir_from_env(Some("/home/bob"), Some(""), None)
+            .expect("resolve");
+        assert_eq!(p, PathBuf::from("/home/bob/.config/btt"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolver_linux_no_xdg_uses_home() {
+        let p = config_dir_from_env(Some("/home/carol"), None, None)
+            .expect("resolve");
+        assert_eq!(p, PathBuf::from("/home/carol/.config/btt"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolver_linux_missing_home_errors() {
+        let err = config_dir_from_env(None, None, None).expect_err("err");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("HOME"),
+            "expected HOME in error, got {msg:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolver_macos_uses_application_support() {
+        let p = config_dir_from_env(Some("/Users/alice"), None, None)
+            .expect("resolve");
+        assert_eq!(
+            p,
+            PathBuf::from("/Users/alice/Library/Application Support/btt")
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn resolver_windows_uses_appdata() {
+        let p = config_dir_from_env(
+            None,
+            None,
+            Some(r"C:\Users\alice\AppData\Roaming"),
+        )
+        .expect("resolve");
+        assert_eq!(
+            p,
+            PathBuf::from(r"C:\Users\alice\AppData\Roaming\btt")
+        );
+    }
+
+    // ── Legacy env-reading integration tests (exercise native_config_dir) ──
+
     #[cfg(target_os = "linux")]
     #[test]
     fn linux_respects_xdg_config_home() {
         let _guard = ENV_LOCK.lock().expect("env lock");
-        let _xdg = EnvGuard::set("XDG_CONFIG_HOME", "/tmp/xdg-btt-test");
+        let _restore = EnvGuard::capture();
+        let _xdg = SingleEnvGuard::set("XDG_CONFIG_HOME", "/tmp/xdg-btt-test");
         let p = native_config_dir().expect("resolve");
         assert_eq!(p, PathBuf::from("/tmp/xdg-btt-test/btt"));
     }
@@ -198,8 +474,9 @@ mod tests {
     #[test]
     fn linux_falls_back_to_dot_config() {
         let _guard = ENV_LOCK.lock().expect("env lock");
-        let _xdg = EnvGuard::unset("XDG_CONFIG_HOME");
-        let _home = EnvGuard::set("HOME", "/home/alice");
+        let _restore = EnvGuard::capture();
+        let _xdg = SingleEnvGuard::unset("XDG_CONFIG_HOME");
+        let _home = SingleEnvGuard::set("HOME", "/home/alice");
         let p = native_config_dir().expect("resolve");
         assert_eq!(p, PathBuf::from("/home/alice/.config/btt"));
     }
@@ -208,8 +485,9 @@ mod tests {
     #[test]
     fn linux_empty_xdg_is_ignored() {
         let _guard = ENV_LOCK.lock().expect("env lock");
-        let _xdg = EnvGuard::set("XDG_CONFIG_HOME", "");
-        let _home = EnvGuard::set("HOME", "/home/bob");
+        let _restore = EnvGuard::capture();
+        let _xdg = SingleEnvGuard::set("XDG_CONFIG_HOME", "");
+        let _home = SingleEnvGuard::set("HOME", "/home/bob");
         let p = native_config_dir().expect("resolve");
         assert_eq!(p, PathBuf::from("/home/bob/.config/btt"));
     }
@@ -218,7 +496,8 @@ mod tests {
     #[test]
     fn macos_uses_application_support() {
         let _guard = ENV_LOCK.lock().expect("env lock");
-        let _home = EnvGuard::set("HOME", "/Users/alice");
+        let _restore = EnvGuard::capture();
+        let _home = SingleEnvGuard::set("HOME", "/Users/alice");
         let p = native_config_dir().expect("resolve");
         assert_eq!(
             p,
@@ -230,10 +509,188 @@ mod tests {
     #[test]
     fn windows_uses_appdata() {
         let _guard = ENV_LOCK.lock().expect("env lock");
-        let _appdata = EnvGuard::set("APPDATA", r"C:\Users\alice\AppData\Roaming");
+        let _restore = EnvGuard::capture();
+        let _appdata =
+            SingleEnvGuard::set("APPDATA", r"C:\Users\alice\AppData\Roaming");
         let p = native_config_dir().expect("resolve");
         assert_eq!(p, PathBuf::from(r"C:\Users\alice\AppData\Roaming\btt"));
     }
+
+    // ── Item 5: VarError::NotUnicode distinct error messages ─────────
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_home_not_present_has_distinct_message() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _restore = EnvGuard::capture();
+        let _xdg = SingleEnvGuard::unset("XDG_CONFIG_HOME");
+        let _home = SingleEnvGuard::unset("HOME");
+        let err = native_config_dir().expect_err("must error");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("HOME environment variable not set"),
+            "expected 'not set' message, got {msg:?}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_home_not_unicode_has_distinct_message() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _restore = EnvGuard::capture();
+        std::env::remove_var("XDG_CONFIG_HOME");
+        // 0xFF is invalid UTF-8 — Rust's `std::env::var` will return
+        // `VarError::NotUnicode` for this.
+        let bad = OsString::from_vec(vec![b'/', b'h', b'o', b'm', b'e', b'/', 0xFF]);
+        std::env::set_var("HOME", &bad);
+        let err = native_config_dir().expect_err("must error");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("non-UTF-8"),
+            "expected 'non-UTF-8' message, got {msg:?}"
+        );
+    }
+
+    // ── Item 2: warn_legacy writes the migration banner ──────────────
+
+    #[test]
+    fn warn_legacy_writes_banner_to_writer() {
+        let legacy = PathBuf::from("/home/alice/.bittensor");
+        let native = PathBuf::from("/home/alice/.config/btt");
+        let mut buf: Vec<u8> = Vec::new();
+        let once = Once::new();
+        warn_legacy_to(&mut buf, &once, &legacy, &native);
+
+        let s = String::from_utf8(buf).expect("utf8");
+        assert!(s.contains("legacy wallet directory at /home/alice/.bittensor"));
+        assert!(s.contains("/home/alice/.config/btt"));
+        assert!(s.contains("mv /home/alice/.bittensor /home/alice/.config/btt"));
+        assert!(s.contains("legacy location until the move is performed"));
+    }
+
+    // ── Item 3: Once semantics — at most one emission ────────────────
+
+    #[test]
+    fn warn_legacy_fires_exactly_once_per_once() {
+        let legacy = PathBuf::from("/home/bob/.bittensor");
+        let native = PathBuf::from("/home/bob/.config/btt");
+        let once = Once::new();
+
+        let mut first: Vec<u8> = Vec::new();
+        warn_legacy_to(&mut first, &once, &legacy, &native);
+        assert!(!first.is_empty(), "first call should emit");
+
+        let mut second: Vec<u8> = Vec::new();
+        warn_legacy_to(&mut second, &once, &legacy, &native);
+        assert!(
+            second.is_empty(),
+            "second call on same Once must emit nothing, got {:?}",
+            String::from_utf8_lossy(&second)
+        );
+
+        // A fresh Once should emit again.
+        let fresh = Once::new();
+        let mut third: Vec<u8> = Vec::new();
+        warn_legacy_to(&mut third, &fresh, &legacy, &native);
+        assert!(!third.is_empty(), "fresh Once should emit");
+    }
+
+    // ── EnvGuard symmetric restore (item 1) ──────────────────────────
+
+    #[test]
+    fn env_guard_restores_all_three_vars_on_drop() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+
+        // Seed known sentinel values we want to see restored.
+        std::env::set_var("HOME", "/orig/home");
+        std::env::set_var("XDG_CONFIG_HOME", "/orig/xdg");
+        std::env::set_var("APPDATA", r"C:\orig\appdata");
+
+        {
+            let tmp = std::env::temp_dir().join("btt-envguard-drop-test");
+            let _ = std::fs::remove_dir_all(&tmp);
+            std::fs::create_dir_all(&tmp).expect("mkdir tmp");
+            let (_guard, _parent) = seat_config_env_at(&tmp);
+
+            // While the guard is live, all three vars should point
+            // inside `tmp`.
+            assert_eq!(
+                std::env::var("HOME").ok().as_deref(),
+                Some(tmp.to_str().expect("tmp is UTF-8"))
+            );
+            assert_ne!(
+                std::env::var("XDG_CONFIG_HOME").ok().as_deref(),
+                Some("/orig/xdg")
+            );
+            assert_ne!(
+                std::env::var("APPDATA").ok().as_deref(),
+                Some(r"C:\orig\appdata")
+            );
+
+            let _ = std::fs::remove_dir_all(&tmp);
+        }
+
+        // Guard dropped: all three restored.
+        assert_eq!(
+            std::env::var("HOME").ok().as_deref(),
+            Some("/orig/home"),
+            "HOME must be restored"
+        );
+        assert_eq!(
+            std::env::var("XDG_CONFIG_HOME").ok().as_deref(),
+            Some("/orig/xdg"),
+            "XDG_CONFIG_HOME must be restored"
+        );
+        assert_eq!(
+            std::env::var("APPDATA").ok().as_deref(),
+            Some(r"C:\orig\appdata"),
+            "APPDATA must be restored"
+        );
+
+        // Cleanup the sentinels so we don't leak into later tests.
+        std::env::remove_var("HOME");
+        std::env::remove_var("XDG_CONFIG_HOME");
+        std::env::remove_var("APPDATA");
+    }
+
+    #[test]
+    fn env_guard_restores_unset_vars_to_unset() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+
+        std::env::remove_var("HOME");
+        std::env::remove_var("XDG_CONFIG_HOME");
+        std::env::remove_var("APPDATA");
+
+        {
+            let tmp = std::env::temp_dir().join("btt-envguard-unset-test");
+            let _ = std::fs::remove_dir_all(&tmp);
+            std::fs::create_dir_all(&tmp).expect("mkdir tmp");
+            let (_guard, _parent) = seat_config_env_at(&tmp);
+            // All three should be set now.
+            assert!(std::env::var("HOME").is_ok());
+            assert!(std::env::var("XDG_CONFIG_HOME").is_ok());
+            assert!(std::env::var("APPDATA").is_ok());
+            let _ = std::fs::remove_dir_all(&tmp);
+        }
+
+        assert!(
+            std::env::var("HOME").is_err(),
+            "HOME should be unset after guard drop"
+        );
+        assert!(
+            std::env::var("XDG_CONFIG_HOME").is_err(),
+            "XDG_CONFIG_HOME should be unset after guard drop"
+        );
+        assert!(
+            std::env::var("APPDATA").is_err(),
+            "APPDATA should be unset after guard drop"
+        );
+    }
+
+    // ── Legacy-fallback integration tests ────────────────────────────
 
     #[cfg(target_os = "linux")]
     #[test]
@@ -241,14 +698,15 @@ mod tests {
         // Pin the ENV lock *and* build in a tempdir so we don't step on
         // real wallets.
         let _guard = ENV_LOCK.lock().expect("env lock");
+        let _restore = EnvGuard::capture();
         let tmp = std::env::temp_dir().join(format!("btt-legacy-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).expect("mkdir tmp");
         let legacy = tmp.join(".bittensor");
         std::fs::create_dir_all(&legacy).expect("mkdir legacy");
 
-        let _home = EnvGuard::set("HOME", tmp.to_str().expect("tmp str"));
-        let _xdg = EnvGuard::set(
+        std::env::set_var("HOME", tmp.to_str().expect("tmp str"));
+        std::env::set_var(
             "XDG_CONFIG_HOME",
             tmp.join(".config").to_str().expect("xdg str"),
         );
@@ -263,6 +721,7 @@ mod tests {
     #[test]
     fn native_path_wins_when_it_exists() {
         let _guard = ENV_LOCK.lock().expect("env lock");
+        let _restore = EnvGuard::capture();
         let tmp = std::env::temp_dir().join(format!("btt-native-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).expect("mkdir tmp");
@@ -273,8 +732,8 @@ mod tests {
         let native = xdg.join("btt");
         std::fs::create_dir_all(&native).expect("mkdir native");
 
-        let _home = EnvGuard::set("HOME", tmp.to_str().expect("tmp str"));
-        let _xdg_g = EnvGuard::set("XDG_CONFIG_HOME", xdg.to_str().expect("xdg str"));
+        std::env::set_var("HOME", tmp.to_str().expect("tmp str"));
+        std::env::set_var("XDG_CONFIG_HOME", xdg.to_str().expect("xdg str"));
 
         let resolved = config_dir().expect("resolve");
         assert_eq!(resolved, native);

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -1628,7 +1628,9 @@ pub fn read_password(prompt: &str) -> Result<Zeroizing<String>, BttError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::paths::ENV_LOCK;
+    use crate::commands::paths::{
+        seat_config_env_at, wallets_parent_for, EnvGuard, ENV_LOCK,
+    };
     use sp_core::Pair as TraitPairAlias;
 
     // Tests that mutate the config-dir env vars cannot run in parallel
@@ -1638,69 +1640,28 @@ mod tests {
     static HOME_LOCK: &std::sync::Mutex<()> = &ENV_LOCK;
 
     /// Pin the btt config directory to `<tmp>` for the duration of the
-    /// currently running test. Sets the per-OS env vars that
+    /// returned guard. Sets the per-OS env vars that
     /// [`crate::commands::paths::config_dir`] consults so the resolver
     /// returns a path inside `tmp`, and ensures the directory tree exists
     /// so the legacy-fallback branch is never taken.
     ///
-    /// Returns the `<tmp>/.../wallets` path — i.e., exactly the parent of
-    /// `<wallet_name>` that `wallet_path(name)` will produce.
+    /// Returns `(guard, wallets_parent)`. The guard restores `HOME`,
+    /// `XDG_CONFIG_HOME`, and `APPDATA` to their prior values on drop;
+    /// the `wallets_parent` is exactly the parent of `<wallet_name>` that
+    /// `wallet_path(name)` will produce.
     ///
-    /// Caller must hold `HOME_LOCK`.
-    fn seat_home_env(tmp: &std::path::Path) -> PathBuf {
-        // Always set HOME (macOS resolver needs it, linux fallback needs
-        // it, and some surrounding test code reads it directly).
-        std::env::set_var("HOME", tmp.to_str().expect("valid path"));
-
-        // On linux (and BSDs, via the fallback arm), pin
-        // XDG_CONFIG_HOME inside tmp so the resolver never looks at the
-        // real `$HOME/.config`.
-        #[cfg(any(
-            target_os = "linux",
-            not(any(target_os = "macos", target_os = "windows"))
-        ))]
-        {
-            let xdg = tmp.join("xdg");
-            std::env::set_var("XDG_CONFIG_HOME", xdg.to_str().expect("valid path"));
-        }
-
-        // On windows, pin APPDATA inside tmp.
-        #[cfg(target_os = "windows")]
-        {
-            let appdata = tmp.join("AppData").join("Roaming");
-            std::env::set_var("APPDATA", appdata.to_str().expect("valid path"));
-        }
-
-        // Compute what `paths::config_dir()` will now return, and make
-        // sure it exists so the legacy-fallback branch (which checks for
-        // `$HOME/.bittensor`) is never taken.
-        let parent = test_wallets_parent(tmp);
-        std::fs::create_dir_all(&parent).expect("create wallets parent");
-        parent
+    /// Delegates to `paths::seat_config_env_at` so the per-OS resolver
+    /// logic lives in exactly one place (see issue #37 item 4). Caller
+    /// must hold `HOME_LOCK`.
+    fn seat_home_env(tmp: &std::path::Path) -> (EnvGuard, PathBuf) {
+        seat_config_env_at(tmp)
     }
 
     /// Compute the `wallets/` parent dir that `paths::config_dir()` will
-    /// resolve to for a given test tmp root, on the host OS.
+    /// resolve to for a given test tmp root, on the host OS. Thin
+    /// delegation to `paths::wallets_parent_for`.
     fn test_wallets_parent(tmp: &std::path::Path) -> PathBuf {
-        #[cfg(target_os = "linux")]
-        {
-            tmp.join("xdg").join("btt").join("wallets")
-        }
-        #[cfg(target_os = "macos")]
-        {
-            tmp.join("Library")
-                .join("Application Support")
-                .join("btt")
-                .join("wallets")
-        }
-        #[cfg(target_os = "windows")]
-        {
-            tmp.join("AppData").join("Roaming").join("btt").join("wallets")
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-        {
-            tmp.join("xdg").join("btt").join("wallets")
-        }
+        wallets_parent_for(tmp)
     }
 
     #[test]
@@ -1868,9 +1829,8 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("btt-perm-{}", std::process::id()));
         let wallet_name = "perm-test";
 
-        let original_home = std::env::var("HOME").ok();
         let _ = std::fs::create_dir_all(&tmp);
-        let wallets_parent = seat_home_env(&tmp);
+        let (_env_guard, wallets_parent) = seat_home_env(&tmp);
 
         let result = create(wallet_name, "default", 12, "perm-pw", false);
 
@@ -1886,9 +1846,7 @@ mod tests {
         // Read first bytes of coldkey to confirm $NACL framing
         let coldkey_bytes = std::fs::read(&coldkey).ok();
 
-        if let Some(h) = original_home {
-            std::env::set_var("HOME", &h);
-        }
+        drop(_env_guard);
         let _ = std::fs::remove_dir_all(&tmp);
 
         result.expect("create should work");
@@ -2031,9 +1989,8 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("btt-load-zeroize-{}", std::process::id()));
         let wallet_name = "load-zero-test";
 
-        let original_home = std::env::var("HOME").ok();
         std::fs::create_dir_all(&tmp).expect("create tmp root");
-        let _wallets_parent = seat_home_env(&tmp);
+        let (_env_guard, _wallets_parent) = seat_home_env(&tmp);
 
         let password = "load-zero-pw";
         let cr = create(wallet_name, "default", 12, password, false).expect("create");
@@ -2042,9 +1999,7 @@ mod tests {
         let sr =
             sign(wallet_name, "default", "hi", false, Some(password)).expect("sign coldkey");
 
-        if let Some(h) = original_home {
-            std::env::set_var("HOME", &h);
-        }
+        drop(_env_guard);
         let _ = std::fs::remove_dir_all(&tmp);
 
         assert_eq!(
@@ -2096,18 +2051,15 @@ mod tests {
         let wallet_name = "test-wallet";
         let _wallet_dir = tmp.join(wallet_name);
 
-        // Override the config-dir env vars for this test.
-        let original_home = std::env::var("HOME").ok();
+        // Override the config-dir env vars for this test. The guard
+        // restores HOME/XDG_CONFIG_HOME/APPDATA on drop.
         std::fs::create_dir_all(&tmp).expect("create tmp root");
-        let _wallets_parent = seat_home_env(&tmp);
+        let (_env_guard, _wallets_parent) = seat_home_env(&tmp);
 
         let password = "test-password";
         let result = create(wallet_name, "default", 12, password, false);
 
-        // Restore HOME
-        if let Some(h) = original_home {
-            std::env::set_var("HOME", &h);
-        }
+        drop(_env_guard);
 
         // Cleanup
         let _ = std::fs::remove_dir_all(&tmp);
@@ -2214,9 +2166,8 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("btt-test-sign-{}", std::process::id()));
         let wallet_name = "sign-test";
 
-        let original_home = std::env::var("HOME").ok();
         std::fs::create_dir_all(&tmp).expect("create tmp root");
-        let _wallets_parent = seat_home_env(&tmp);
+        let (_env_guard, _wallets_parent) = seat_home_env(&tmp);
 
         let password = "sign-test-pw";
         let cr = create(wallet_name, "default", 12, password, false).expect("create should work");
@@ -2240,9 +2191,7 @@ mod tests {
             .expect("verify hotkey sig");
         assert!(hk_vr.valid);
 
-        if let Some(h) = original_home {
-            std::env::set_var("HOME", &h);
-        }
+        drop(_env_guard);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
@@ -2263,9 +2212,11 @@ mod tests {
     // is absent regardless of the force flag.
 
     /// Helper: seat the config-dir env vars at a fresh temp dir and
-    /// return the temp path. The caller is responsible for restoring
-    /// HOME and removing the dir.
-    fn seat_home(tag: &str) -> (PathBuf, Option<String>) {
+    /// return `(tmp, env_guard)`. The guard restores HOME /
+    /// XDG_CONFIG_HOME / APPDATA on drop (symmetric restoration, see
+    /// issue #37 item 1). Pair with [`restore_home`] to also blow away
+    /// the temp directory.
+    fn seat_home(tag: &str) -> (PathBuf, EnvGuard) {
         let tmp = std::env::temp_dir().join(format!(
             "btt-force-{}-{}-{}",
             tag,
@@ -2277,16 +2228,13 @@ mod tests {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0)
         ));
-        let original_home = std::env::var("HOME").ok();
         std::fs::create_dir_all(&tmp).expect("create tmp root");
-        let _ = seat_home_env(&tmp);
-        (tmp, original_home)
+        let (guard, _parent) = seat_home_env(&tmp);
+        (tmp, guard)
     }
 
-    fn restore_home(tmp: PathBuf, original: Option<String>) {
-        if let Some(h) = original {
-            std::env::set_var("HOME", &h);
-        }
+    fn restore_home(tmp: PathBuf, guard: EnvGuard) {
+        drop(guard);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
@@ -2714,9 +2662,8 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("btt-test-regen-{}", std::process::id()));
         let wallet_name = "regen-test";
 
-        let original_home = std::env::var("HOME").ok();
         std::fs::create_dir_all(&tmp).expect("create tmp root");
-        let _wallets_parent = seat_home_env(&tmp);
+        let (_env_guard, _wallets_parent) = seat_home_env(&tmp);
 
         let password = "regen-pw";
         let cr = create(wallet_name, "default", 12, password, false).expect("create should work");
@@ -2736,9 +2683,7 @@ mod tests {
         assert!(vr.valid);
         assert_eq!(sign_result.ss58_address, cr.coldkey_ss58);
 
-        if let Some(h) = original_home {
-            std::env::set_var("HOME", &h);
-        }
+        drop(_env_guard);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
Closes #37.

Five LOW / cosmetic items from the PR #36 barbarian review, batched into one PR per builder's discretion. All non-blocking, no behavior change on the happy path. No new dependencies.

## Fixes

### 1. Symmetric env guard (`paths::EnvGuard`)
`src/commands/paths.rs:243-319`, `src/commands/wallet_keys.rs:1633-1671`

`EnvGuard::capture()` snapshots `HOME`, `XDG_CONFIG_HOME`, and `APPDATA` together, and `Drop` restores all three. `seat_config_env_at(tmp)` returns the guard alongside the computed `wallets/` parent. The old `seat_home_env` (wallet_keys) and `seat_home`/`restore_home` (wallet_keys) helpers now delegate to it, replacing the asymmetric `original_home` save/restore that leaked `XDG_CONFIG_HOME` between tests.

### 2. `warn_legacy` writer injection + banner assertion
`src/commands/paths.rs:148-179`

`warn_legacy_to(&mut dyn Write, &Once, legacy, new)` is the core implementation. `warn_legacy` is a thin wrapper that pins `stderr().lock()` and the process-wide `LEGACY_WARNING` static. This required refactoring `warn_legacy` to take a writer — option 3 from the issue brief (no new dep, no subprocess spawn). `warn_legacy_writes_banner_to_writer` now asserts the exact banner text end-to-end.

### 3. `Once`-semantics test
`src/commands/paths.rs:148-179` (refactor), test at `warn_legacy_fires_exactly_once_per_once`

Because `warn_legacy_to` takes `&Once`, the test supplies a fresh one, hits it twice, and asserts the second call writes zero bytes. A third call with a *different* fresh `Once` does emit — so future refactors that drop the guard or replace `Once` with an unconditional call will fail the test.

### 4. Single per-OS resolver site
`src/commands/paths.rs:56-121` (`config_dir_from_env`), `src/commands/paths.rs:236-274` (test helpers), `src/commands/wallet_keys.rs:1673-1678`

`config_dir_from_env(home, xdg, appdata) -> Result<PathBuf, BttError>` is the single source of truth for `cfg(target_os)` branching (mirrors the `expand_tilde` refactor shape from PR #45). `native_config_dir` reads env vars and dispatches. `wallets_parent_for` (pub(crate) test helper) also dispatches through it. The old `test_wallets_parent` duplicate in `wallet_keys::tests` is now a thin delegation. Three cfg sites → one.

### 5. `VarError::NotUnicode` distinct messages
`src/commands/paths.rs:37-49` (`read_env_var`), distinct tests at `linux_home_not_present_has_distinct_message` and `linux_home_not_unicode_has_distinct_message`

`read_env_var` matches on `VarError` explicitly: `NotPresent` → `"X environment variable not set"`, `NotUnicode(_)` → `"X contains non-UTF-8 bytes"`. Used by `native_config_dir` and `legacy_dir`.

## Tests added

Nine new tests in `paths::tests`:

- `env_guard_restores_all_three_vars_on_drop` — set sentinels, seat, drop, assert all three restored
- `env_guard_restores_unset_vars_to_unset` — unset → seat → drop → assert all three unset
- `warn_legacy_writes_banner_to_writer` — asserts full banner text into a `Vec<u8>`
- `warn_legacy_fires_exactly_once_per_once` — `Once` semantics, plus fresh-`Once` re-emission check
- `linux_home_not_present_has_distinct_message` — exercises `NotPresent` arm
- `linux_home_not_unicode_has_distinct_message` — sets a `0xFF`-containing `OsString` for HOME, exercises `NotUnicode` arm
- `resolver_linux_xdg_wins` — synthetic values, no env mutation
- `resolver_linux_empty_xdg_falls_back_to_home` — synthetic
- `resolver_linux_no_xdg_uses_home` — synthetic
- `resolver_linux_missing_home_errors` — synthetic
- `resolver_macos_uses_application_support` (cfg-gated)
- `resolver_windows_uses_appdata` (cfg-gated)

## Verification

- `cargo build` — ok
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --release paths` — 15 passed, 0 failed
- `cargo test --release wallet_keys` — 69 passed, 1 ignored, 0 failed

## No new deps

Confirmed. `Cargo.toml` unchanged.