### PR TITLE
[cryptid] ci: add workspace test workflow (#58)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,100 @@
+name: tests
+
+# Workspace test suite. This workflow exists because cryptid's builder
+# subagents operate on a host where `cargo test --workspace` routinely
+# exceeds the bash-tool timeout, so they cannot locally verify that
+# their code actually works before pushing. The fix is to offload the
+# slow verification to GitHub's runners: the builder pushes its branch
+# and `gh run watch`es this workflow instead of stalling on a local
+# cargo test that will never finish. See issue #58 for the full
+# incident history (builder stall on #11/#57 phase A).
+#
+# Triggers are deliberately broad:
+#   - push on any branch: every branch you own you are responsible for,
+#     and immediate feedback matters more than runner minutes.
+#   - pull_request: mandatory merge gate. The followup to this PR asks
+#     the repo owner to add `tests / test` as a required status check
+#     on main via branch protection.
+#   - workflow_dispatch: lets a builder (or a human) re-run against an
+#     arbitrary ref without needing to push an empty commit.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or SHA to test (defaults to the default branch)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # For workflow_dispatch with a `ref` input, check that out;
+          # otherwise fall back to the event's default ref.
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Rust toolchain
+        # Pinned to match rust-toolchain.toml and btcli-compat.yml.
+        # When bumping, update all three.
+        uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-tests-
+
+      - name: Build tests
+        # --locked fails fast on lockfile drift so we never silently
+        # resolve a different dep graph than what's checked in.
+        run: cargo build --tests --workspace --locked
+
+      - name: Run tests
+        # --no-fail-fast so one failing test doesn't mask the others.
+        # --test-threads=2 keeps memory under control on the runner.
+        # tee to test-output.log so the summary and artifact steps can
+        # read the full transcript regardless of exit code.
+        run: |
+          set -o pipefail
+          cargo test --workspace --no-fail-fast --locked -- --test-threads=2 2>&1 | tee test-output.log
+
+      - name: Summarize failures
+        if: failure()
+        run: |
+          {
+            echo "## Test failure summary"
+            echo ""
+            echo "Last 200 lines of \`test-output.log\`:"
+            echo ""
+            echo '```'
+            tail -n 200 test-output.log || echo "(no test-output.log found)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-output-${{ github.run_id }}
+          path: test-output.log
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,14 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Raised from 30 to 60 on 2026-04-14 after the first PR #60 run hit
+    # the 30-min cap. Root cause: the wallet_keys module's tests each
+    # exercise real argon2id KDF at production work factor, taking 60-120s
+    # per test. On ubuntu-latest's 2 vCPU runner with --test-threads=2,
+    # the wallet_keys module alone needs ~30-40 min. A proper fix (a
+    # test-only KDF profile with a low work factor) is tracked separately;
+    # the 60-min ceiling is the pragmatic stopgap.
+    timeout-minutes: 60
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
Closes #58

## What this adds

`.github/workflows/tests.yml` — a workspace-wide test runner that executes `cargo test --workspace` on GitHub's runners instead of on the builder host.

- **Triggers**: `push` on any branch, `pull_request` on every PR, and `workflow_dispatch` with an optional `ref` input for manual runs against arbitrary refs.
- **Runtime**: `ubuntu-latest`, `timeout-minutes: 30`, `contents: read` only.
- **Toolchain**: pinned to `dtolnay/rust-toolchain@1.94.1` to match `rust-toolchain.toml` and `btcli-compat.yml`.
- **Cache**: `actions/cache@v4` under the `cargo-tests-` prefix so it does not collide with btcli-compat's cache.
- **Build**: `cargo build --tests --workspace --locked` — fails fast on lockfile drift.
- **Test**: `cargo test --workspace --no-fail-fast --locked -- --test-threads=2` piped through `tee test-output.log` so a failing test does not mask the others and the full transcript is captured regardless of exit code.
- **Summary**: on failure the last 200 lines of `test-output.log` are written to `$GITHUB_STEP_SUMMARY`.
- **Artifact**: `test-output.log` uploaded on every run (`if: always()`), 30-day retention.

No new cargo deps, no `cargo-nextest`, no `sccache`. Pure workflow file addition, nothing touched outside `.github/workflows/tests.yml`.

## Why

cryptid's builder subagents operate on a host where `cargo test --workspace` routinely exceeds the bash-tool timeout on a single shell command. This has caused concrete incidents:

- #11/#57 phase A builder stalled ~37 minutes into a `cargo test`, got killed, and had to be recovered via a 4-commit hand-patch loop.
- PR #57 was pushed without a local clippy gate as a consequence of that recovery.

Before: builders stall on `cargo test`, get killed by the tool timeout, main session sometimes crashes.
After: builders push their branch, `gh run watch` this workflow, and wait for `tests / test` to come back green. The slow verification happens on GitHub's runners, which have no 10-minute shell cap.

## Critical note for the merger

After this PR merges, the repo owner should add `tests / test` as a **required status check on `main`** via branch protection. This is a manual step (admin-only) and is deliberately not part of this PR — see #58 for context.

## CI status at time of posting

Will update once `tests / test` (new, self-testing), `verify` (btcli-compat), `clippy`, and `combine` (dep-audit) settle. This workflow is self-testing: the new `tests / test` check will run on this very PR because it triggers on `pull_request`.