### PR TITLE
[cryptid] dep-audit: wrap report sections in collapsible <details> blocks

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -209,32 +209,32 @@ jobs:
           set -uo pipefail
           artifacts_root='dep-audit-artifacts'
           combined='combined-report.md'
-
-          {
-            printf '## Dep audit\n\n'
-            printf 'Run against `%s` on `%s`.\n\n' \
-              "$(git rev-parse --short HEAD)" \
-              "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-          } > "${combined}"
+          sections='sections.md'
+          : > "${sections}"
 
           overall_exit=0
           # Fixed order so the combined report is deterministic regardless
           # of matrix scheduling. checksum comes last so the supply-chain
-          # tripwire verdict is the final thing a reviewer sees.
+          # tripwire is the final section a reviewer expands.
           for tool in cargo-audit cargo-deny cargo-outdated checksum; do
             artifact_dir="${artifacts_root}/dep-audit-${tool}-${{ github.run_id }}"
             report="${artifact_dir}/report-${tool}.md"
             status_file="${artifact_dir}/status-${tool}.txt"
 
             if [ ! -f "${report}" ]; then
-              printf '### %s\n\n' "${tool}" >> "${combined}"
-              printf '(report missing — job crashed before writing output)\n\n' >> "${combined}"
+              # Auto-expand the placeholder so a missing artifact is loud.
+              {
+                printf '<details open>\n'
+                printf '<summary><strong>%s</strong></summary>\n\n' "${tool}"
+                printf '(report missing — job crashed before writing output)\n\n'
+                printf '</details>\n\n'
+              } >> "${sections}"
               overall_exit=1
               continue
             fi
 
-            cat "${report}" >> "${combined}"
-            printf '\n' >> "${combined}"
+            cat "${report}" >> "${sections}"
+            printf '\n' >> "${sections}"
 
             if [ -f "${status_file}" ]; then
               tool_exit="$(cat "${status_file}")"
@@ -246,11 +246,21 @@ jobs:
             fi
           done
 
-          if [ "${overall_exit}" = "0" ]; then
-            printf 'STATUS: PASS\n' >> "${combined}"
-          else
-            printf 'STATUS: FAIL\n' >> "${combined}"
-          fi
+          # Write the combined report with STATUS at the TOP so the
+          # high-level verdict is visible without scrolling or
+          # expanding any <details> block.
+          {
+            printf '## Dep audit\n\n'
+            printf 'Run against `%s` on `%s`.\n\n' \
+              "$(git rev-parse --short HEAD)" \
+              "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+            if [ "${overall_exit}" = "0" ]; then
+              printf 'STATUS: PASS\n\n'
+            else
+              printf 'STATUS: FAIL\n\n'
+            fi
+            cat "${sections}"
+          } > "${combined}"
 
           echo '--- combined report ---'
           cat "${combined}"

--- a/scripts/dep-audit/checksum.py
+++ b/scripts/dep-audit/checksum.py
@@ -413,8 +413,20 @@ def main(argv=None):
             stale.append(key)
 
     # --- report --------------------------------------------------------
+    #
+    # The body is wrapped in a collapsible <details> block so the
+    # combined dep-audit PR comment stays scannable. On a clean run the
+    # reader sees only the "dep-checksum tripwire" summary; on a
+    # mismatch, new-dep, or stale-entry result the block is emitted
+    # `<details open>` so the failure is visible without a click.
+    #
+    # GFM requires blank lines after <summary> and before </details>
+    # for the inner markdown (fenced code blocks, **bold**) to parse.
+    status_fail = bool(mismatches) or (bool(new_entries) and not args.update)
+    details_attr = " open" if (status_fail or stale) else ""
     report_lines = []
-    report_lines.append("### dep-checksum tripwire")
+    report_lines.append(f"<details{details_attr}>")
+    report_lines.append("<summary><strong>dep-checksum tripwire</strong></summary>")
     report_lines.append("")
     report_lines.append(
         f"Tracked: {len(current)} deps; DB entries: {len(db)}; "
@@ -483,8 +495,13 @@ def main(argv=None):
         report_lines.append("All deps match the committed DB. No drift.")
         report_lines.append("")
 
-    status_fail = bool(mismatches) or (bool(new_entries) and not args.update)
+    # status_fail was computed above the details-header so the opening
+    # tag could pick `<details open>` on failure; reuse it here for the
+    # inner STATUS line so the body of the <details> block still terminates
+    # in a human-readable PASS/FAIL verdict.
     report_lines.append("STATUS: " + ("FAIL" if status_fail else "PASS"))
+    report_lines.append("")
+    report_lines.append("</details>")
 
     report_text = "\n".join(report_lines) + "\n"
     sys.stdout.write(report_text)

--- a/scripts/dep-audit/run-one.sh
+++ b/scripts/dep-audit/run-one.sh
@@ -37,6 +37,28 @@ cd "${REPO_ROOT}"
 
 emit() { printf '%s\n' "$*"; }
 
+# Emit a collapsible <details> block. First arg is the summary label,
+# second arg is "open" (0 = collapsed by default, 1 = expanded because
+# the section is a failure the reader should see without clicking), and
+# the body is read from stdin.
+#
+# The blank lines around the body are load-bearing: GitHub Flavored
+# Markdown only parses nested markdown inside a <details> block when
+# there is a blank line after <summary> and before </details>. Without
+# the blanks the body renders as raw HTML and the code fences show up
+# as literal backticks.
+emit_details() {
+  local summary="$1" open_flag="$2" open_attr=""
+  if [ "${open_flag}" = "1" ]; then
+    open_attr=" open"
+  fi
+  printf '<details%s>\n' "${open_attr}"
+  printf '<summary><strong>%s</strong></summary>\n' "${summary}"
+  printf '\n'
+  cat
+  printf '\n</details>\n'
+}
+
 # Audit ignores: see issue #52. The single source of truth is
 # `scripts/dep-audit/rustsec-ignores.jsonl`; `render-ignores.sh --audit`
 # emits the `--ignore RUSTSEC-xxxx` pairs for cargo-audit and
@@ -49,26 +71,30 @@ RENDER_DENY_TOML="${SCRIPT_DIR}/render-deny-toml.sh"
 
 run_audit() {
   # cargo-audit section, prefixed by a direct-deps inventory so the
-  # audited surface is visible alongside the advisory output.
-  emit '### Direct deps'
-  emit ''
-  emit '```'
-  cargo tree --depth 1 --quiet 2>/dev/null || emit '(cargo tree failed)'
-  emit '```'
-  emit ''
+  # audited surface is visible alongside the advisory output. Both
+  # sub-sections are wrapped in collapsible <details> blocks so the
+  # combined PR comment can be scanned in a single screen; cargo-audit
+  # auto-expands if it reports an advisory.
 
+  # --- Direct deps --------------------------------------------------
+  local direct_tree direct_count total_count
+  direct_tree="$(cargo tree --depth 1 --quiet 2>/dev/null || printf '(cargo tree failed)\n')"
   # Count direct deps for the summary line. cargo tree's tree-drawing
   # characters are emitted with leading whitespace; match anything that
   # starts with a tree-corner glyph anywhere on the line.
-  local direct_count total_count
   direct_count="$(cargo tree --depth 1 --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
   total_count="$(cargo tree --quiet 2>/dev/null | grep -cE '[├└]──' || true)"
-  emit "Total: ${direct_count:-0} direct, ${total_count:-0} entries in resolved tree (transitive)."
+
+  emit_details 'Direct deps' 0 <<EOF
+\`\`\`
+${direct_tree}
+\`\`\`
+
+Total: ${direct_count:-0} direct, ${total_count:-0} entries in resolved tree (transitive).
+EOF
   emit ''
 
-  emit '### cargo-audit'
-  emit ''
-  emit '```'
+  # --- cargo-audit --------------------------------------------------
   # Pull the ignore list out of rustsec-ignores.jsonl at run time so
   # this script never drifts from deny.toml. Each non-empty line of
   # render output is a single CLI token (either `--ignore` or an id);
@@ -84,60 +110,76 @@ run_audit() {
   local audit_output audit_status
   audit_output="$(cargo audit --quiet "${audit_ignore_args[@]}" 2>&1)"
   audit_status=$?
-  emit "${audit_output}"
-  emit '```'
   if [ ${audit_status} -ne 0 ]; then
-    emit ''
-    emit '**FAIL**: cargo-audit reported one or more advisories.'
+    emit_details 'cargo-audit' 1 <<EOF
+\`\`\`
+${audit_output}
+\`\`\`
+
+**FAIL**: cargo-audit reported one or more advisories.
+EOF
     return 1
   fi
-  emit ''
-  emit 'no advisories.'
+  emit_details 'cargo-audit' 0 <<EOF
+\`\`\`
+${audit_output}
+\`\`\`
+
+no advisories.
+EOF
   return 0
 }
 
 run_deny() {
-  emit '### cargo-deny'
-  emit ''
   # Render deny.toml from the template + jsonl into a tempfile; the
   # committed tree never holds a generated deny.toml (see issue #52).
   local deny_config
   deny_config="$(mktemp -t btt-deny.XXXXXX.toml)"
   if ! bash "${RENDER_DENY_TOML}" "${deny_config}"; then
     rm -f "${deny_config}"
-    emit '```'
-    emit '(render-deny-toml.sh failed; cannot run cargo-deny)'
-    emit '```'
+    emit_details 'cargo-deny' 1 <<'EOF'
+```
+(render-deny-toml.sh failed; cannot run cargo-deny)
+```
+EOF
     return 1
   fi
-  emit '```'
   # cargo-deny argument order: subcommand first, options after.
   local deny_output deny_status
   deny_output="$(cargo deny check --config "${deny_config}" 2>&1)"
   deny_status=$?
   rm -f "${deny_config}"
-  emit "${deny_output}"
-  emit '```'
   if [ ${deny_status} -ne 0 ]; then
-    emit ''
-    emit '**FAIL**: cargo-deny reported one or more issues.'
+    emit_details 'cargo-deny' 1 <<EOF
+\`\`\`
+${deny_output}
+\`\`\`
+
+**FAIL**: cargo-deny reported one or more issues.
+EOF
     return 1
   fi
-  emit ''
-  emit 'no issues.'
+  emit_details 'cargo-deny' 0 <<EOF
+\`\`\`
+${deny_output}
+\`\`\`
+
+no issues.
+EOF
   return 0
 }
 
 run_outdated() {
-  emit '### cargo-outdated'
-  emit ''
-  emit '```'
   local outdated_output
   outdated_output="$(cargo outdated --depth 1 --root-deps-only 2>&1 || true)"
-  emit "${outdated_output}"
-  emit '```'
-  emit ''
-  emit '_cargo-outdated is informational only and does not affect the audit status._'
+  # cargo-outdated never fails the audit, so it stays collapsed.
+  emit_details 'cargo-outdated' 0 <<EOF
+\`\`\`
+${outdated_output}
+\`\`\`
+
+_cargo-outdated is informational only and does not affect the audit status._
+EOF
   return 0
 }
 


### PR DESCRIPTION
## Summary

The dep-audit PR comment is five sections of cargo output (Direct deps, cargo-audit, cargo-deny, cargo-outdated, dep-checksum tripwire) and dominates the PR conversation on every push. Neeraj asked for it to be rendered collapsible (2026-04-14) so reviewers can scan a PR without the audit drowning out the actual discussion.

This PR wraps each section in a GitHub Flavored Markdown `<details>` block. The high-level verdict is surfaced at the top of the combined report instead of buried at the bottom, so the one thing reviewers care about stays visible without any clicks.

Sections that FAIL emit `<details open>` so advisories, deny errors, checksum mismatches, new deps, and stale DB entries stay visible. Clean sections stay collapsed.

## Files changed

- `scripts/dep-audit/run-one.sh` — new `emit_details` helper; `run_audit`, `run_deny`, `run_outdated` now emit collapsible blocks. Direct-deps and cargo-audit are both wrapped; cargo-audit auto-expands on advisory, cargo-deny auto-expands on deny error.
- `scripts/dep-audit/checksum.py` — wraps the tripwire body in a `<details>` block; auto-expands on mismatch, new-dep, or stale entries. The inner `STATUS: PASS|FAIL` line stays inside the block so the script still produces a standalone verdict when run locally.
- `.github/workflows/dep-audit.yml` — buffer section bodies first, compute `overall_exit`, then write the combined report with `STATUS: PASS|FAIL` at the TOP instead of appending at the bottom. Missing-artifact placeholders are emitted as `<details open>` so a crashed matrix cell is loud.

## Rendered output (clean run)

```markdown
## Dep audit

Run against `abc1234` on `main`.

STATUS: PASS

<details>
<summary><strong>Direct deps</strong></summary>

` ` `
btt v0.1.0
├── foo v1.0.0
└── bar v2.0.0
` ` `

Total: 2 direct, 42 entries in resolved tree (transitive).

</details>

<details>
<summary><strong>cargo-audit</strong></summary>

` ` `
Scanning... no vulnerabilities
` ` `

no advisories.

</details>

... (cargo-deny, cargo-outdated, dep-checksum tripwire: same shape)
```

Per-section template emitted by `emit_details`:

```bash
emit_details() {
  local summary="$1" open_flag="$2" open_attr=""
  if [ "${open_flag}" = "1" ]; then
    open_attr=" open"
  fi
  printf '<details%s>\n' "${open_attr}"
  printf '<summary><strong>%s</strong></summary>\n' "${summary}"
  printf '\n'
  cat
  printf '\n</details>\n'
}
```

The blank lines after `<summary>` and before `</details>` are load-bearing: GFM only parses inner markdown (fenced code, `**bold**`) inside a `<details>` block when the blanks are present. Without them the body renders as raw HTML.

## Failure mode

On a failure, the offending section is emitted as `<details open>`:

- `cargo-audit` advisory → `<details open>` on the cargo-audit block
- `cargo-deny` error → `<details open>` on the cargo-deny block
- `dep-checksum` mismatch, new deps (non-update), or stale entries → `<details open>` on the tripwire block

Readers see failures without clicking. `STATUS: FAIL` is also at the top of the report.

## Constraints honored

- No new dependencies.
- No `src/` changes.
- `STATUS: PASS|FAIL` is always visible (now at the top).
- The per-tool exit status semantics, the jsonl ignore list, and the dep-audit matrix structure are unchanged.

## Verification

- `bash scripts/dep-audit/test_render_ignores.sh` — 18/18 pass
- `python3 -m py_compile scripts/dep-audit/checksum.py` — clean
- `python3 scripts/dep-audit/checksum.py --report` on the current tree — emits the expected `<details>` block with inner STATUS line
- `bash -n scripts/dep-audit/run-one.sh` — clean
- Simulated combine step against fake per-tool reports — produces the full layout shown above
- `cargo clippy --all-targets -- -D warnings` — clean (2m 33s)

## CI

Posting, will verify before requesting review.

## Test plan
- [ ] dep-audit workflow passes against this PR and the posted comment renders with all five collapsible sections
- [ ] STATUS line is visible at the top without expanding any block
- [ ] All clean sections start collapsed