### PR TITLE
[cryptid] rpc+stake: validate_url defense-in-depth + sr25519 signer wire-format lock (#59)

### DIFF
--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -969,5 +969,98 @@ mod tests {
         let result = resolve_address(None, None);
         assert!(result.is_err());
     }
+
+    // -- Sr25519Signer wire-format tripwire ---------------------------------
+    //
+    // This test exists to catch silent subxt/sp_core API drift. The signer
+    // path was hand-rolled in PR #57 when subxt 0.50 dropped `PairSigner`,
+    // and at the time of merge the barbarian review verified byte-identical
+    // output vs. the old implementation. But neither type-checking nor
+    // clippy will notice if a future subxt bump reorders `MultiSignature`
+    // variants or changes `sr25519::Signature` layout — the refactor would
+    // still compile, and signed extrinsics would silently fail on-chain.
+    //
+    // The test locks three things:
+    //   1. The public key derived from a known seed (catches seed-derivation
+    //      drift in sp-core's sr25519 HKDF path).
+    //   2. The SCALE variant tag of `subxt::utils::MultiSignature::Sr25519`
+    //      (catches variant reordering — Ed25519 = 0, Sr25519 = 1, Ecdsa = 2
+    //      per the enum order in subxt-0.50 `utils/multi_signature.rs`).
+    //   3. The 64-byte signature body validates against the hard-coded
+    //      public key via `sr25519::Pair::verify` (catches any layout or
+    //      semantic change in the signature bytes themselves).
+    //
+    // We cannot assert raw signature bytes because sr25519 signatures are
+    // randomised (schnorrkel nonce). Verification closes the loop.
+    //
+    // If this test fails, DO NOT just re-pin the expected values. First
+    // confirm the wire format is actually unchanged by round-tripping
+    // against a known-good client, *then* update the pinned values here.
+    #[test]
+    fn sr25519_signer_wire_format_locked() {
+        use sp_core::sr25519;
+        use subxt::ext::codec::Encode;
+        use subxt::tx::Signer as _;
+
+        // Hard-coded 32-byte seed. Not a well-known dev key — we want the
+        // derivation itself under test, not a re-use of //Alice.
+        const SEED: [u8; 32] = [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54,
+            0x32, 0x10, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0x00, 0x11, 0x22, 0x33,
+            0x44, 0x55, 0x66, 0x77,
+        ];
+
+        // The expected sr25519 public key derived from SEED via
+        // `sp_core::sr25519::Pair::from_seed`. Locking this catches any
+        // change in sp-core's mini-secret → keypair expansion.
+        const EXPECTED_PUBKEY_HEX: &str =
+            "5e63279eb48e4656a4070ec89346105860d1628bf17c10e76c35f555be5aaf31";
+
+        // Fixed signer payload — the bytes that would normally be the
+        // extrinsic signed payload. 32 bytes of 0x42 is simply a fixed
+        // input so the verification side of the test is deterministic.
+        const SIGNER_PAYLOAD: [u8; 32] = [0x42; 32];
+
+        let pair = sr25519::Pair::from_seed(&SEED);
+        let signer = Sr25519Signer::new(pair.clone());
+
+        // (1) Public key lock.
+        let derived_pk: [u8; 32] = PairTrait::public(&pair).0;
+        assert_eq!(
+            hex::encode(derived_pk),
+            EXPECTED_PUBKEY_HEX,
+            "sr25519 public key derived from fixed seed changed — sp-core derivation drift"
+        );
+
+        // (2) SCALE-encoded MultiSignature tripwire. The signer returns a
+        // `subxt::utils::MultiSignature`. We SCALE-encode it directly and
+        // check:
+        //   - byte 0 is the variant tag (must be 0x01 for Sr25519)
+        //   - total length is 1 + 64 = 65 bytes (variant tag + sig body)
+        let sig = signer.sign(&SIGNER_PAYLOAD);
+        let encoded: Vec<u8> = sig.encode();
+        assert_eq!(
+            encoded.len(),
+            65,
+            "SCALE-encoded MultiSignature length changed — sig body size or tag width drift"
+        );
+        assert_eq!(
+            encoded[0], 0x01,
+            "MultiSignature::Sr25519 variant tag changed — enum variant reorder in subxt"
+        );
+
+        // (3) The 64-byte signature body must still verify against the
+        // public key under sp-core's sr25519 semantics. This catches any
+        // change in the on-wire signature format itself.
+        let sig_bytes: [u8; 64] = encoded[1..]
+            .try_into()
+            .expect("65-byte encoding minus 1-byte tag is 64");
+        let sp_sig = sr25519::Signature::from_raw(sig_bytes);
+        let sp_pub = sr25519::Public::from_raw(derived_pk);
+        assert!(
+            <sr25519::Pair as PairTrait>::verify(&sp_sig, SIGNER_PAYLOAD.as_slice(), &sp_pub),
+            "SCALE-decoded sig body did not verify — sr25519 signature layout drift"
+        );
+    }
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -48,7 +48,17 @@ pub fn resolve_endpoint(url: Option<&str>, network: Option<&str>) -> Result<Stri
     }
 }
 
-/// Validate that a URL uses ws:// or wss:// scheme.
+/// Validate that a URL uses the `ws://` or `wss://` scheme.
+///
+/// **Scope**: this check is scheme-only. It accepts any `ws://<host>` URL,
+/// including remote hosts — it does NOT require TLS for non-loopback hosts.
+/// A user who supplies `ws://entrypoint-finney.opentensor.ai` via config
+/// will get a plaintext connection to mainnet.
+///
+/// Tightening this policy to host-aware (require `wss://` for all
+/// non-loopback hosts) is tracked in ErgodicLabs/btt#69. Until that lands,
+/// the guarantee of this function is narrow: it rejects `http://`,
+/// `https://`, `file://`, and the empty string, not much more.
 pub fn validate_url(url: &str) -> Result<(), BttError> {
     if !url.starts_with("ws://") && !url.starts_with("wss://") {
         return Err(BttError::connection(
@@ -63,14 +73,16 @@ pub fn validate_url(url: &str) -> Result<(), BttError> {
 ///
 /// Uses [`OnlineClient::from_insecure_url`] because the `local` network
 /// shorthand points at a plain `ws://127.0.0.1:9944`; subxt 0.50's
-/// `from_url` rejects non-TLS endpoints outright. Scheme validation for
-/// explicit user input is enforced by [`validate_url`] above, and this
-/// function also calls it as defense-in-depth so any future internal caller
-/// that skips [`resolve_endpoint`] still gets scheme enforcement.
+/// `from_url` rejects non-TLS endpoints outright.
+///
+/// This function calls [`validate_url`] as belt-and-suspenders for callers
+/// that bypass [`resolve_endpoint`]. Read the scope note on
+/// [`validate_url`]: the check is scheme-only and does not prevent a
+/// `wss://` → `ws://` downgrade against a remote host. Host-aware policy
+/// is tracked in ErgodicLabs/btt#69.
 pub async fn connect(endpoint: &str) -> Result<OnlineClient<PolkadotConfig>, BttError> {
-    // Defense-in-depth: redundant with resolve_endpoint for user-supplied
-    // URLs, but the check costs nothing and catches internal callers that
-    // construct endpoints directly without going through resolve_endpoint.
+    // Defense-in-depth, narrow: rejects http://, https://, file://, and the
+    // empty string. Does NOT enforce TLS for remote hosts (see #69).
     validate_url(endpoint)?;
     tokio::time::timeout(
         CONNECT_TIMEOUT,
@@ -86,10 +98,10 @@ pub async fn connect(endpoint: &str) -> Result<OnlineClient<PolkadotConfig>, Btt
 pub async fn connect_full(
     endpoint: &str,
 ) -> Result<(OnlineClient<PolkadotConfig>, LegacyRpc), BttError> {
-    // See note on `connect`: we accept `ws://` for the `local` shorthand
-    // and validate scheme ourselves in `validate_url`. This redundant
-    // guard is defense-in-depth for internal callers that bypass
-    // `resolve_endpoint`.
+    // See note on `connect`: the validate_url guard is scheme-only and
+    // narrow. It rejects http://, https://, file://, and the empty string.
+    // It does NOT prevent a wss://→ws:// downgrade against a remote host;
+    // host-aware policy is tracked in #69.
     validate_url(endpoint)?;
     let rpc_client = tokio::time::timeout(
         CONNECT_TIMEOUT,
@@ -175,6 +187,21 @@ mod tests {
     #[test]
     fn validate_url_https_returns_error() {
         assert!(validate_url("https://example.com").is_err());
+    }
+
+    #[test]
+    fn validate_url_ws_to_remote_host_is_accepted_by_design() {
+        // Pin the current scheme-only policy: `ws://` to a REMOTE host
+        // is accepted. This is not ideal (a plaintext connection to a
+        // mainnet mirror passes the check), but it is the documented
+        // current behavior. When #69 lands and validate_url becomes
+        // host-aware, this test should be updated to assert rejection.
+        // Until then, removing or flipping this assertion without also
+        // tightening the policy would hide the gap.
+        assert!(
+            validate_url("ws://entrypoint-finney.opentensor.ai").is_ok(),
+            "scheme-only guard accepts ws:// to any host (see #69 for host-aware policy)"
+        );
     }
 
     // -- connect/connect_full defense-in-depth tests --

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -64,8 +64,14 @@ pub fn validate_url(url: &str) -> Result<(), BttError> {
 /// Uses [`OnlineClient::from_insecure_url`] because the `local` network
 /// shorthand points at a plain `ws://127.0.0.1:9944`; subxt 0.50's
 /// `from_url` rejects non-TLS endpoints outright. Scheme validation for
-/// explicit user input is enforced by [`validate_url`] above.
+/// explicit user input is enforced by [`validate_url`] above, and this
+/// function also calls it as defense-in-depth so any future internal caller
+/// that skips [`resolve_endpoint`] still gets scheme enforcement.
 pub async fn connect(endpoint: &str) -> Result<OnlineClient<PolkadotConfig>, BttError> {
+    // Defense-in-depth: redundant with resolve_endpoint for user-supplied
+    // URLs, but the check costs nothing and catches internal callers that
+    // construct endpoints directly without going through resolve_endpoint.
+    validate_url(endpoint)?;
     tokio::time::timeout(
         CONNECT_TIMEOUT,
         OnlineClient::<PolkadotConfig>::from_insecure_url(endpoint),
@@ -81,7 +87,10 @@ pub async fn connect_full(
     endpoint: &str,
 ) -> Result<(OnlineClient<PolkadotConfig>, LegacyRpc), BttError> {
     // See note on `connect`: we accept `ws://` for the `local` shorthand
-    // and validate scheme ourselves in `validate_url`.
+    // and validate scheme ourselves in `validate_url`. This redundant
+    // guard is defense-in-depth for internal callers that bypass
+    // `resolve_endpoint`.
+    validate_url(endpoint)?;
     let rpc_client = tokio::time::timeout(
         CONNECT_TIMEOUT,
         RpcClient::from_insecure_url(endpoint),
@@ -166,5 +175,43 @@ mod tests {
     #[test]
     fn validate_url_https_returns_error() {
         assert!(validate_url("https://example.com").is_err());
+    }
+
+    // -- connect/connect_full defense-in-depth tests --
+    //
+    // These tests lock the guarantee that `rpc::connect*` reject non-ws/wss
+    // URLs *before* handing them to subxt. The check is redundant with
+    // `resolve_endpoint` for user-facing paths, but is the last line of
+    // TLS-enforcement defense for any internal caller that constructs a
+    // raw string (see issue #59). The test is synchronous because the
+    // guard fires before any network I/O.
+
+    #[test]
+    fn connect_rejects_http_scheme_without_network_io() {
+        // Build a tokio runtime locally so we can drive the async fn to
+        // completion. The validate_url guard runs before any socket is
+        // touched, so this is network-free.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = rt.block_on(connect("http://untrusted.example.com"));
+        assert!(
+            result.is_err(),
+            "connect must reject non-ws/wss schemes via validate_url"
+        );
+    }
+
+    #[test]
+    fn connect_full_rejects_http_scheme_without_network_io() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = rt.block_on(connect_full("https://untrusted.example.com"));
+        assert!(
+            result.is_err(),
+            "connect_full must reject non-ws/wss schemes via validate_url"
+        );
     }
 }


### PR DESCRIPTION
Closes #59

Two non-correctness hardening items from the PR #57 (subxt 0.38→0.50) barbarian review. Both close off silent-drift classes that type-checking and clippy cannot see.

## Item 1 — `rpc::connect` / `connect_full` defense-in-depth

**File**: `src/rpc.rs`

`connect` and `connect_full` previously delegated scheme enforcement entirely to `resolve_endpoint → validate_url`. Any internal caller that builds an endpoint string directly (e.g. `wallet_faucet`, or any future code path) would hand it straight to subxt's `from_insecure_url` with no `ws://`/`wss://` check.

Now both entry points call `validate_url(endpoint)?` at the top. The redundancy is the point: it is the *last line* of scheme defense for paths that skip `resolve_endpoint`. Callers that already pre-validate pay one cheap string-prefix check; callers that forgot get rejected before any socket is opened.

Two new unit tests (`connect_rejects_http_scheme_without_network_io`, `connect_full_rejects_http_scheme_without_network_io`) drive the async fns to the guard check and assert rejection. The guard fires before any network I/O, so the tests are net-free and fast.

## Item 2 — `sr25519_signer_wire_format_locked`

**File**: `src/commands/stake.rs`

A tripwire for the hand-rolled `Sr25519Signer` that replaced the deleted `PairSigner` in #57. sr25519 signatures are nondeterministic (schnorrkel nonce), so raw-byte pinning is impossible. The test locks **three** invariants separately:

1. **Public key lock** — the key derived from a fixed 32-byte seed via `sp_core::sr25519::Pair::from_seed` matches a pinned hex value. Catches drift in sp-core's mini-secret → keypair expansion.
2. **SCALE variant-tag + length lock** — the SCALE-encoded `subxt::utils::MultiSignature` must be exactly 65 bytes with `encoded[0] == 0x01` (Sr25519 variant index). Catches enum variant reordering (e.g. a future subxt that puts Ecdsa first) and any change in signature body width.
3. **Verification lock** — the 64-byte signature body, decoded from the SCALE output, must verify against the pinned public key via `sr25519::Pair::verify`. Catches any change in on-wire signature layout.

### Class of regression caught

A future subxt bump that reorders `MultiSignature` variants, or an sp-core bump that changes `sr25519::Signature` layout, would today still type-check and pass clippy — and signed extrinsics would silently fail on chain with zero CI signal. This test fails loud instead, with a comment that tells the next maintainer not to just re-pin the values without confirming the wire format is actually unchanged.

## Scope

- `src/rpc.rs` — 1 validate_url call in each of `connect` / `connect_full`, 2 new tests, doc comment updates
- `src/commands/stake.rs` — 1 new test (`sr25519_signer_wire_format_locked`)

**No new deps.** Everything is reached through existing `sp-core`, `subxt`, and `hex` imports. `subxt::ext::codec::Encode` is the re-export used for SCALE encoding; `parity-scale-codec` is already in `Cargo.lock` transitively.

## Local verification

```
cargo check --all-targets              # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --bin btt                   # 184 passed, 0 failed, 1 ignored
```

The two new `rpc::` tests and the new `commands::stake::` test all pass; full suite is green.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin btt` (184 passed)
- [ ] CI green on the PR matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)