### PR TITLE
[cryptid] ci: dep-audit matrix cells now exit with tool status (#65)

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -116,10 +116,19 @@ jobs:
           VERBOSE: ${{ inputs.verbose && '1' || '0' }}
         run: |
           chmod +x scripts/dep-audit/run-one.sh
-          # Suspend bash -e around the script so its exit status flows
-          # through to the artifact instead of aborting the job. The
-          # combine job re-derives pass/fail from the per-tool status
-          # files in the downloaded artifacts.
+          # Suspend bash -e around the script so we can capture the
+          # exit status into the status file (which the combine job
+          # re-reads) before propagating it out of the step. The
+          # artifact upload step below is `if: always()` so the report
+          # and status file still upload on tool failure, and the
+          # combine job has `if: !cancelled()` so it still runs and
+          # posts its verdict even when a matrix cell fails.
+          #
+          # Issue #65: the previous version ended with tool_exit=0 as
+          # the last expression, so every matrix cell reported SUCCESS
+          # regardless of tool result. Now the cell's status check
+          # mirrors the tool's own exit — `audit (cargo-deny): fail`
+          # when cargo-deny reported advisories, `pass` when it didn't.
           set +e
           scripts/dep-audit/run-one.sh '${{ matrix.tool }}' \
             > 'report-${{ matrix.tool }}.md' \
@@ -134,6 +143,7 @@ jobs:
             cat 'stderr-${{ matrix.tool }}.log'
           fi
           echo "tool_exit=${tool_exit}" >> "$GITHUB_OUTPUT"
+          exit "${tool_exit}"
 
       - name: Upload ${{ matrix.tool }} artifact
         if: always()
@@ -192,7 +202,12 @@ jobs:
   combine:
     runs-on: ubuntu-latest
     needs: [audit, checksum]
-    if: always()
+    # `!cancelled()` runs combine on both success and failure of the
+    # matrix cells and checksum job, but NOT when the whole workflow is
+    # cancelled mid-run. Issue #65: we need combine to run even when a
+    # matrix cell fails (so reviewers still get the aggregated PR
+    # comment) while still honoring cancellation.
+    if: ${{ !cancelled() }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #65.

## Problem

`.github/workflows/dep-audit.yml` wraps `run-one.sh` in `set +e` so one failing tool doesn't abort the whole matrix (the combine job re-aggregates from artifacts). The trade-off: the step's last expression was `echo "tool_exit=..." >> $GITHUB_OUTPUT`, whose own exit is 0 — so GitHub's status-check layer saw every matrix cell as SUCCESS even when run-one.sh reported advisories.

Combine still caught the real failure through its text-based re-check (that's how #57 stayed honest), but a reviewer scanning the PR check list would see `audit (cargo-deny): pass` and conclude cargo-deny was clean when it wasn't. Belt-and-suspenders that shouldn't have to exist.

## Fix (option 1 from the issue)

1. **Matrix step**: append `exit "${tool_exit}"`. The cell's status check now mirrors the tool's own exit.
2. **Combine job**: change `if: always()` to `if: ${{ !cancelled() }}`. `always()` runs even on workflow cancellation; `!cancelled()` runs on success and failure but not cancellation.
3. **Artifact upload** already has `if: always()` — unchanged. Reports and status files still upload on tool failure so combine has what it needs.
4. **fail-fast** already `false` on the matrix (line 81) — unchanged. One failing cell does not cancel its siblings.

Only `.github/workflows/dep-audit.yml` is touched. No script or source changes.

## Before / after semantics

| Scenario                          | Per-cell check | Combine verdict |
|-----------------------------------|----------------|-----------------|
| All tools clean                   | pass (was pass)| pass (unchanged)|
| cargo-deny fires advisory         | fail (was pass)| fail (unchanged)|
| run-one.sh crashes before status  | fail (was pass)| fail (unchanged)|
| Workflow cancelled mid-run        | cancelled      | skipped         |

Combine's verdict logic is untouched. Only the per-cell display aligns with reality.

## Verification

- `cargo check --all-targets` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/dep-audit.yml"))'` parses

## CI expectations for this PR

This PR has no failing advisories, so the new `exit "${tool_exit}"` path exits 0 for every matrix cell — the PR's own dep-audit checks stay green. The behavior change only becomes visible on a PR that actually trips one of the tools.

## Test plan

- [ ] Confirm `dep-audit / audit (cargo-audit)`, `audit (cargo-deny)`, `audit (cargo-outdated)`, `checksum`, and `combine` all report success on this PR
- [ ] Future PR that introduces an un-ignored advisory should show the firing matrix cell as `fail` (not `pass`) and combine as `fail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)