### PR TITLE
[cryptid] ci: dep-audit checksum job exits with tool status (#71)

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -186,6 +186,13 @@ jobs:
             cat stderr-checksum.log
           fi
           echo "tool_exit=${tool_exit}" >> "$GITHUB_OUTPUT"
+          # Mirror the #65/#70 fix: propagate the tool exit so the per-cell
+          # `checksum` status check accurately reflects whether the tripwire
+          # fired. The upload step below is `if: always()` so the artifact
+          # still reaches combine even when we exit non-zero here. The
+          # combine job's `if: !cancelled()` predicate already tolerates
+          # failed needs, so this change is strictly additive.
+          exit "${tool_exit}"
 
       - name: Upload checksum artifact
         if: always()


### PR DESCRIPTION
Closes #71.

## Summary

Mirrors the #65/#70 fix on the `checksum` job of the dep-audit workflow.

Before: the `Run dep-checksum tripwire` step captured `tool_exit=$?` into a status file and `$GITHUB_OUTPUT`, but left the step's final exit code at 0. So GitHub's status-check display reported `dep-audit / checksum: pass` even when the tripwire fired (mismatch, new-in-CI entry, stale DB). The combine job caught the failure via `overall_exit`, so the PR still went red, but the per-cell display was misleading — same class of bug the barbarian caught on PR #70's review.

After: `exit "${tool_exit}"` is the last line of the run block. The upload step is already `if: always()`, so the artifact still reaches combine on failure. The combine job's `if: !cancelled()` predicate (landed in #70) already tolerates failed `needs`, so this change is strictly additive.

## Diff

One file, 7 additions:

\`\`\`yaml
          echo \"tool_exit=\${tool_exit}\" >> \"\$GITHUB_OUTPUT\"
+          # Mirror the #65/#70 fix: propagate the tool exit so the per-cell
+          # \`checksum\` status check accurately reflects whether the tripwire
+          # fired. The upload step below is \`if: always()\` so the artifact
+          # still reaches combine even when we exit non-zero here. The
+          # combine job's \`if: !cancelled()\` predicate already tolerates
+          # failed needs, so this change is strictly additive.
+          exit \"\${tool_exit}\"
\`\`\`

## Verification

- \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/dep-audit.yml').read())\"\` → ok
- \`cargo check --all-targets\` clean (the change is in a workflow file, but running check anyway to prove the repo builds at this commit)
- \`cargo clippy --all-targets -- -D warnings\` clean
- This PR's own CI will be the live test of the new behavior on the happy path (no tripwire firing).

## Scope

One file, one commit, strictly additive.