### PR TITLE
[cryptid] wallet: NIT cleanup from #62 + #66 barbarian reviews (#63, #67)

### DIFF
--- a/src/commands/wallet_faucet.rs
+++ b/src/commands/wallet_faucet.rs
@@ -48,6 +48,28 @@
 // condition. See issue #55 and the btcli reference for the canonical
 // endpoint list.
 
+//! # Testnet safety
+//!
+//! The faucet command refuses to submit unless THREE independent safety
+//! checks all pass:
+//!
+//! 1. **URL blocklist** — rejects substring matches against known mainnet
+//!    endpoints (see [`check_url_is_not_mainnet`]).
+//! 2. **Genesis-hash check** — rejects the finney mainnet genesis hash
+//!    fetched via `chain_getBlockHash(0)` after connect (see
+//!    [`check_genesis_is_not_mainnet`]).
+//! 3. **Signature binding (implicit)** — the signed extrinsic embeds the
+//!    genesis hash it was signed against. A malicious RPC that lies about
+//!    genesis at handshake time produces an extrinsic whose signature
+//!    fails validation on real mainnet, so even a two-guard bypass cannot
+//!    materialize a valid mainnet transaction.
+//!
+//! All three would have to fail for a mainnet extrinsic to submit
+//! successfully. The first two are explicit code checks. The third falls
+//! out of substrate's extrinsic signing protocol and does not require any
+//! btt-side code — it is documented here so future readers understand
+//! why the explicit guards are sufficient rather than insufficient.
+
 use std::io::Write as _;
 use std::time::{Duration, Instant};
 
@@ -201,6 +223,16 @@ pub async fn run(params: FaucetParams<'_>) -> Result<FaucetResult, BttError> {
         return Err(BttError::invalid_input(
             "--update-interval must be >= 1",
         ));
+    }
+
+    // The solver is strictly single-threaded today; `num_processes` only
+    // strides the nonce space so a future parallel implementation can be
+    // dropped in without changing the command surface (see `solve_pow`).
+    // Warn users who pass >1 expecting multi-core throughput.
+    if num_processes > 1 {
+        eprintln!(
+            "note: --num-processes > 1 strides the nonce space for future parallelism but the current solver is single-threaded"
+        );
     }
 
     // Decrypt the coldkey EARLY so a bad password fails before we open
@@ -491,14 +523,17 @@ pub(crate) fn solve_pow(
             });
         }
 
-        // Cap checks run every `update_interval` iterations so they
-        // don't dominate the hot loop. `update_interval` must be >= 1.
+        // Iteration cap is checked every iteration so the ceiling is
+        // hard — a simple u64 compare is not worth batching. The
+        // wall-time check (Instant::now syscall) and the progress
+        // report stay batched on `update_interval` boundaries to keep
+        // the hot loop lean. `update_interval` must be >= 1.
+        if iterations >= max_iterations {
+            return Err(BttError::invalid_input(format!(
+                "pow timed out: iteration cap {max_iterations} reached after {iterations} attempts"
+            )));
+        }
         if iterations.is_multiple_of(update_interval) {
-            if iterations >= max_iterations {
-                return Err(BttError::invalid_input(format!(
-                    "pow timed out: iteration cap {max_iterations} reached after {iterations} attempts"
-                )));
-            }
             if start.elapsed() >= max_duration {
                 return Err(BttError::invalid_input(format!(
                     "pow timed out: wall-clock cap {}s reached after {iterations} attempts",

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -1414,13 +1414,17 @@ fn build_pub_key_json(pair: &Pair) -> PubKeyFileData {
     }
 }
 
-/// Derive a 32-byte NaCl secretbox key from a password using libsodium's
-/// `argon2i13::derive_key` parameters (Argon2i, v0x13, t=8, m=512 MiB, p=1,
-/// hardcoded `NACL_SALT`). Byte-for-byte compatible with btwallet/btcli in
-/// release builds; under `cfg(test)` the params drop to a minimal profile
-/// (see `ARGON2_*` constants) so test runs are fast. Anything that cares
-/// about matching the on-disk envelope format should call
-/// `derive_key_with_params` with `PROD_*` values directly.
+/// In release builds, produces a 32-byte NaCl secretbox key byte-for-byte
+/// compatible with btwallet/btcli (libsodium's `argon2i13::derive_key` with
+/// the SENSITIVE profile: Argon2i, v0x13, t=8, m=512 MiB, p=1, hardcoded
+/// `NACL_SALT`).
+///
+/// **Under `cfg(test)`**, this function uses a weakened 1 MiB / t=1 profile
+/// (see the `ARGON2_*` constants) so test runs are fast. Tests that assert
+/// on-the-wire compatibility with external libsodium implementations must
+/// call [`derive_key_with_params`] directly with the `PROD_ARGON2_*`
+/// constants instead; see `derive_key_matches_libsodium_reference` and
+/// `decrypts_btwallet_reference_vector` for examples.
 fn derive_key(password: &[u8]) -> Result<Zeroizing<[u8; NACL_KEY_LEN]>, BttError> {
     derive_key_with_params(
         password,
@@ -1972,8 +1976,39 @@ mod tests {
     #[test]
     #[ignore = "helper for producing hex blobs consumed by external libsodium"]
     fn dump_blob_for_python() {
+        // Emit a blob the python libsodium reference will decrypt. Under
+        // cfg(test), `encrypt_key_data` would route through the weakened
+        // argon2 profile (1 MiB / t=1) and the blob would fail to open
+        // under libsodium's SENSITIVE profile. Inline the envelope
+        // construction here with `derive_key_with_params` pinned to the
+        // PROD_* constants, mirroring `decrypts_btwallet_reference_vector`.
+        use rand::RngCore;
+        use xsalsa20poly1305::aead::Aead;
+        use xsalsa20poly1305::{KeyInit, XSalsa20Poly1305};
+
         let pt = b"btt-to-btwallet-interop-check";
-        let enc = encrypt_key_data(pt, "roundtrip-pw").expect("encrypt");
+        let password = "roundtrip-pw";
+
+        let key = derive_key_with_params(
+            password.as_bytes(),
+            PROD_ARGON2_M_COST_KIB,
+            PROD_ARGON2_T_COST,
+            PROD_ARGON2_PARALLELISM,
+        )
+        .expect("argon2 derive");
+
+        let mut nonce_bytes = [0u8; NACL_NONCE_LEN];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = xsalsa20poly1305::Nonce::from(nonce_bytes);
+
+        let cipher = XSalsa20Poly1305::new(xsalsa20poly1305::Key::from_slice(key.as_slice()));
+        let ciphertext = cipher.encrypt(&nonce, pt.as_slice()).expect("encrypt");
+
+        let mut enc = Vec::with_capacity(NACL_MAGIC.len() + NACL_NONCE_LEN + ciphertext.len());
+        enc.extend_from_slice(NACL_MAGIC);
+        enc.extend_from_slice(&nonce_bytes);
+        enc.extend_from_slice(&ciphertext);
+
         eprintln!("BTT_ENC_BLOB={}", hex::encode(&enc));
     }
 


### PR DESCRIPTION
Bundle of five non-blocking NITs from the #62 (argon2 cfg(test) profile) and #66 (wallet faucet) barbarian reviews. Touches only `src/commands/wallet_keys.rs` and `src/commands/wallet_faucet.rs`.

## Fixes

### `wallet_keys.rs` (from #63 / #62 review)

- **63.1 — `dump_blob_for_python` under cfg(test)**: the `#[ignore]`'d helper was routing through `encrypt_key_data` -> `derive_key` -> the weakened cfg(test) argon2 profile (1 MiB / t=1), so emitted blobs would not decrypt under python libsodium's SENSITIVE profile. Inlined the envelope construction with `derive_key_with_params` pinned to `PROD_ARGON2_*`, mirroring `decrypts_btwallet_reference_vector`.
- **63.2 — `derive_key` rustdoc lead-in**: rewrote so the cfg(test) weakened-profile caveat is up front rather than buried behind a "byte-for-byte compatible with btwallet/btcli" lead. Points readers to `derive_key_with_params` + `PROD_ARGON2_*` for any on-the-wire compat assertions.

### `wallet_faucet.rs` (from #67 / #66 review)

- **67.1 — hard iteration cap**: moved the `iterations >= max_iterations` check out of the `if iterations.is_multiple_of(update_interval)` block. Previously the cap could overshoot by up to `update_interval` iterations before firing. Wall-time check stays batched (the `Instant::now()` syscall is not worth every-iteration; a u64 compare is). Existing cap tests still pass.
- **67.2 — `num_processes` stderr note**: the solver is single-threaded today and `num_processes` only strides the nonce space for future parallelism. Added a one-line `eprintln!` when `num_processes > 1` so users who expected multi-core speedup see why CPU utilization does not change.
- **67.3 — three-safety-check module doc**: added a `//! # Testnet safety` block to the top of `wallet_faucet.rs` documenting the implicit third safety check: even if a user bypassed the URL blocklist AND the genesis-hash guard, a malicious RPC lying about genesis at handshake would produce an extrinsic whose signature fails validation on real mainnet. Documents why the two explicit guards are sufficient rather than insufficient.

Closes #63
Closes #67

## Local gates

- `cargo check --all-targets`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test commands::wallet_keys::`: 72 passed, 1 ignored (`dump_blob_for_python`)
- `cargo test commands::wallet_faucet::`: 20 passed

## Test plan

- [ ] CI green on the merge queue matrix
- [ ] Manual smoke: `cargo test -- --ignored dump_blob_for_python` emits a hex blob whose PROD-params argon2 key decrypts it (optional; human-invoked)
- [ ] Review the module-doc rendering under `cargo doc --open` for `wallet_faucet`