### PR TITLE
[cryptid] dep-audit: renderer hardening NITs from #54 barbarian (#56)

### DIFF
--- a/scripts/dep-audit/render-ignores.sh
+++ b/scripts/dep-audit/render-ignores.sh
@@ -60,6 +60,8 @@ fi
 
 # Validate the jsonl up front so a malformed line fails loudly with a
 # line number instead of silently producing a short ignore list.
+# blank lines and lines parsing to null are tolerated; non-blank lines
+# must parse as JSON with a non-empty "id" field (#56 NIT 56.3).
 if ! jq -e 'has("id")' "${JSONL}" >/dev/null 2>&1; then
   # jq -e over a jsonl stream returns false only if the last value is
   # false/null; a parse error exits non-zero. Either way, re-run with a

--- a/scripts/dep-audit/run-one.sh
+++ b/scripts/dep-audit/run-one.sh
@@ -96,17 +96,35 @@ EOF
 
   # --- cargo-audit --------------------------------------------------
   # Pull the ignore list out of rustsec-ignores.jsonl at run time so
-  # this script never drifts from deny.toml. Each non-empty line of
-  # render output is a single CLI token (either `--ignore` or an id);
-  # mapfile preserves them as array elements without word-splitting
-  # hazards.
+  # this script never drifts from deny.toml. Capture the renderer to a
+  # tempfile first and check its exit status explicitly: a process
+  # substitution (`< <(...)`) would swallow the subshell's exit status
+  # and silently feed a partial `--ignore` list to cargo-audit if the
+  # renderer ever mutated to emit-then-fail. That is the PR #51 drift
+  # class this whole jsonl pipeline was introduced to prevent (#54
+  # barbarian NIT 56.1).
+  local audit_tmp
+  audit_tmp="$(mktemp -t btt-audit-ignores.XXXXXX)"
+  if ! bash "${RENDER_IGNORES}" --audit > "${audit_tmp}"; then
+    rm -f "${audit_tmp}"
+    emit_details 'cargo-audit' 1 <<'EOF'
+```
+(render-ignores.sh --audit failed; cannot run cargo-audit)
+```
+EOF
+    return 1
+  fi
+  # Each non-empty line of render output is a single CLI token (either
+  # `--ignore` or an id); word-splitting turns the pair into the two
+  # array elements cargo-audit expects.
   local audit_ignore_args=()
   local line
   while IFS= read -r line; do
     [ -z "${line}" ] && continue
     # shellcheck disable=SC2206
     audit_ignore_args+=( ${line} )
-  done < <(bash "${RENDER_IGNORES}" --audit)
+  done < "${audit_tmp}"
+  rm -f "${audit_tmp}"
   local audit_output audit_status
   audit_output="$(cargo audit --quiet "${audit_ignore_args[@]}" 2>&1)"
   audit_status=$?

--- a/scripts/dep-audit/test_render_ignores.sh
+++ b/scripts/dep-audit/test_render_ignores.sh
@@ -10,7 +10,7 @@
 # matrix runs, so regressions in the renderers fail fast and loud
 # instead of bleeding into the audit jobs as "missing advisory" errors.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RENDER_IGNORES="${SCRIPT_DIR}/render-ignores.sh"


### PR DESCRIPTION
Closes #56

Three non-blocking NITs from the #54 barbarian review of the jsonl rustsec-ignore renderer. None currently permit drift; all three plug small latent holes so a future mutation cannot quietly regress to the PR #51 class.

## Changes

### NIT 56.1 — `run_audit` tempfile capture + exit check

`scripts/dep-audit/run-one.sh`: the renderer was consumed via process substitution (`< <(bash "${RENDER_IGNORES}" --audit)`), which swallows the subshell's exit status. A future renderer mutation that emit-then-failed would have silently fed a short `--ignore` list to cargo-audit — the exact drift class the jsonl pipeline was introduced to prevent. Now captures to a tempfile, checks exit status explicitly, and emits a `FAIL` details block if the renderer fails, mirroring the existing `run_deny` pattern.

### NIT 56.2 — `set -e` on the test harness

`scripts/dep-audit/test_render_ignores.sh` was `set -uo pipefail`. Mutation testing in the #54 barbarian review confirmed the 18 assertions still catch drop-first/drop-last regressions via count + content checks, but a future `assert_*` helper that relied on abort-on-failure would have behaved unexpectedly. Added `set -e`. All 18 assertions continue to pass locally (verified pre-commit).

### NIT 56.3 — documented `jq` blank-line behaviour

`scripts/dep-audit/render-ignores.sh`: one-line comment near the `jq -e 'has("id")'` validator noting that blank lines and lines parsing to null are tolerated; non-blank lines must be JSON with a non-empty `id`. Behaviour is unchanged.

## Verification

- `bash scripts/dep-audit/test_render_ignores.sh` — 18 tests, 0 failed
- `bash scripts/dep-audit/run-one.sh cargo-audit` — renderer path executes cleanly (cargo-audit not installed on host, which exercises the post-renderer exit path, not the tempfile-capture path)
- `bash scripts/dep-audit/run-one.sh cargo-deny` — OK
- `bash scripts/dep-audit/run-one.sh cargo-outdated` — OK
- `cargo check --all-targets` — OK (warm cache)
- `cargo clippy --all-targets -- -D warnings` — OK (warm cache)

CI will exercise the real cargo-audit, cargo-deny, and cargo-outdated matrix on top of the hardened run-one.sh; I will verify `all_success` on the status rollup before anyone merges.

## Scope

Only touches the three files named in the issue. No new deps. No Rust changes.