### PR TITLE
[cryptid] ci: bump GitHub Actions past Node.js 20 deprecation

### DIFF
--- a/.github/workflows/btcli-compat.yml
+++ b/.github/workflows/btcli-compat.yml
@@ -55,7 +55,7 @@ jobs:
       BTCLI_COMPAT_PY: "3.11"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         # Pinned to match rust-toolchain.toml. When bumping, update both.
@@ -64,7 +64,7 @@ jobs:
           components: clippy
 
       - name: Cargo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -80,7 +80,7 @@ jobs:
         run: cargo build --release
 
       - name: Setup Python ${{ env.BTCLI_COMPAT_PY }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.BTCLI_COMPAT_PY }}
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload compat vectors and report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: btcli-compat-vectors-${{ github.run_id }}
           path: btcli-compat-out/

--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run render-ignores.sh / render-deny-toml.sh unit tests
         run: |
@@ -83,7 +83,7 @@ jobs:
         tool: [cargo-audit, cargo-deny, cargo-outdated]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         # Pinned to match rust-toolchain.toml. When bumping, update both.
@@ -91,7 +91,7 @@ jobs:
 
       - name: Cache ${{ matrix.tool }} binary
         id: tool-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/${{ matrix.tool }}
           key: cargo-${{ matrix.tool }}-${{ runner.os }}-${{ hashFiles('scripts/dep-audit/tool-versions.txt') }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload ${{ matrix.tool }} artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dep-audit-${{ matrix.tool }}-${{ github.run_id }}
           path: |
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run dep-checksum tripwire
         id: run
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload checksum artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dep-audit-checksum-${{ github.run_id }}
           path: |
@@ -217,7 +217,7 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all matrix artifacts
         uses: actions/download-artifact@v4
@@ -331,7 +331,7 @@ jobs:
 
       - name: Upload combined report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dep-audit-combined-${{ github.run_id }}
           path: combined-report.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         # Pinned to match rust-toolchain.toml. When bumping, update both.
@@ -45,7 +45,7 @@ jobs:
           components: clippy
 
       - name: Cargo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # For workflow_dispatch with a `ref` input, check that out;
           # otherwise pin to the exact commit that triggered this run
@@ -74,7 +74,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cargo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload test output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-output-${{ github.run_id }}
           path: test-output.log


### PR DESCRIPTION
Closes the GHA Node.js 20 deprecation-warning item that the #58 builder flagged on PR #60.

## Summary

All four btt workflows use GitHub Actions whose runtime is Node.js 20, which GitHub is deprecating in favor of Node.js 24. This PR does the straight major-version bump:

| action | old | new | notes |
|---|---|---|---|
| \`actions/checkout\` | v4 | v6 | Node 24 runtime |
| \`actions/cache\` | v4 | v5 | Node 24 runtime |
| \`actions/upload-artifact\` | v4 | v7 | Node 24 runtime |
| \`actions/setup-python\` | v5 | v6 | Node 24 runtime |

\`dtolnay/rust-toolchain\` stays pinned to \`@1.94.1\` — it's a Rust-based action, not Node-based, and the deprecation does not apply.

## Files touched

- \`.github/workflows/btcli-compat.yml\`
- \`.github/workflows/dep-audit.yml\`
- \`.github/workflows/lint.yml\`
- \`.github/workflows/tests.yml\`

## Verification

- \`python3 -c \"import yaml; yaml.safe_load(open(<each>).read())\"\` → ok for all four
- CI will be the authoritative test of the new runtime (the new action versions actually running on GitHub's infra)

## Scope

Strictly additive version bumps. No other changes to workflow semantics. No source files touched.