### PR TITLE
[cryptid] wallet create: return both coldkey and hotkey mnemonics in JSON envelope (closes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ built-in default (finney).
 | `chain info`             | Display chain name, runtime version, and current block number.  |
 | `chain balance <ss58>`   | Query the free TAO balance for an SS58 address.                 |
 | `wallet list`            | List wallets in the btt config directory.                        |
-| `wallet create`          | Create a new wallet (coldkey + hotkey pair) and print mnemonic.  |
+| `wallet create`          | Create a new wallet and print both coldkey + hotkey mnemonics.   |
 | `wallet new-coldkey`     | Generate a new coldkey only.                                     |
 | `wallet new-hotkey`      | Generate a new hotkey under an existing wallet.                  |
 | `wallet regen-coldkey`   | Restore a coldkey from mnemonic or seed.                         |
@@ -70,7 +70,8 @@ btt chain balance <ss58_address>
 # List local wallets
 btt wallet list
 
-# Create a new wallet (coldkey + hotkey). Prints the coldkey mnemonic.
+# Create a new wallet (coldkey + hotkey). Prints BOTH mnemonics in the
+# JSON envelope: `coldkey_mnemonic` and `hotkey_mnemonic`.
 btt wallet create --name alice [--hotkey default] [--n-words 12|24] \
                   [--password-file <path>] [--force]
 
@@ -113,9 +114,10 @@ the generated mnemonic as part of the JSON response envelope. Treat the
 output as secret material: do not run these in a shared terminal, and do
 not redirect stdout to a file you will forget about. The mnemonic is the
 only way to recover the key if the encrypted wallet file is lost or the
-password is forgotten. (Note: as of this writing only the coldkey
-mnemonic is surfaced on `wallet create`; the hotkey mnemonic is written
-silently to disk. Issue #78 tracks promoting it into the response.)
+password is forgotten. `wallet create` emits BOTH mnemonics under the
+`coldkey_mnemonic` and `hotkey_mnemonic` fields of the JSON `data`
+object (issue #78). This is a breaking change from the pre-#78 shape
+that used a single `mnemonic` field for the coldkey phrase only.
 
 ### Stake
 

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -326,12 +326,28 @@ const ARGON2_PARALLELISM: u32 = 1;
 
 // ── Output types ──────────────────────────────────────────────────────────
 
-#[derive(Serialize)]
+// `CreateResult` is the JSON payload `btt wallet create` emits on stdout.
+// It carries BOTH fresh mnemonics: one for the newly-minted coldkey and
+// one for the newly-minted hotkey. Per issue #78, an automation caller
+// that captures stdout must be able to recover both phrases from that
+// single buffer — the pre-#78 shape only exposed the coldkey phrase and
+// quietly wrote the hotkey phrase to disk, which strands any caller that
+// does not also re-read the on-disk hotkey file.
+//
+// The struct derives `ZeroizeOnDrop` so that the mnemonic `String`s (and
+// the less-sensitive ss58 fields along for the ride) have their heap
+// bytes overwritten the moment the result is dropped. `main.rs` drops
+// the result immediately after `print_success` returns, so the window
+// in which fresh phrases sit on the heap is bounded by a single JSON
+// serialization. `Serialize` is implemented by-reference and does not
+// conflict with `Drop`, so the two derives compose cleanly.
+#[derive(Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct CreateResult {
     pub wallet_name: String,
     pub coldkey_ss58: String,
     pub hotkey_ss58: String,
-    pub mnemonic: String,
+    pub coldkey_mnemonic: String,
+    pub hotkey_mnemonic: String,
 }
 
 #[derive(Serialize)]
@@ -1009,9 +1025,18 @@ fn create_into_staging(
         }
     }
 
-    let mnemonic_out = cold_phrase.clone();
+    // Snapshot BOTH phrases into the result struct before zeroizing the
+    // originals. Per issue #78 the hotkey phrase must flow out through
+    // stdout alongside the coldkey phrase, not only through the on-disk
+    // hotkey file. The result struct is `ZeroizeOnDrop`, so these clones
+    // are scrubbed from the heap as soon as `main.rs` drops the value
+    // after `print_success`.
+    let coldkey_mnemonic_out = cold_phrase.clone();
+    let hotkey_mnemonic_out = hot_phrase.clone();
 
-    // Zeroize sensitive material that will not be returned to the caller.
+    // Zeroize the original secret buffers. The seeds are not returned to
+    // the caller at all; the phrases survive only via the clones above,
+    // which the result struct's `ZeroizeOnDrop` will scrub on drop.
     cold_phrase.zeroize();
     cold_seed.zeroize();
     hot_phrase.zeroize();
@@ -1021,7 +1046,8 @@ fn create_into_staging(
         wallet_name: wallet_name.to_string(),
         coldkey_ss58: cold_ss58,
         hotkey_ss58: hot_ss58,
-        mnemonic: mnemonic_out,
+        coldkey_mnemonic: coldkey_mnemonic_out,
+        hotkey_mnemonic: hotkey_mnemonic_out,
     })
 }
 
@@ -2430,8 +2456,43 @@ mod tests {
         assert_eq!(result.wallet_name, wallet_name);
         assert!(result.coldkey_ss58.starts_with('5'));
         assert!(result.hotkey_ss58.starts_with('5'));
-        let words: Vec<&str> = result.mnemonic.split_whitespace().collect();
-        assert_eq!(words.len(), 12);
+
+        // Both mnemonics must be present in the JSON envelope (issue #78).
+        let cold_words: Vec<&str> = result.coldkey_mnemonic.split_whitespace().collect();
+        assert_eq!(cold_words.len(), 12, "coldkey mnemonic should be 12 words");
+        let hot_words: Vec<&str> = result.hotkey_mnemonic.split_whitespace().collect();
+        assert_eq!(hot_words.len(), 12, "hotkey mnemonic should be 12 words");
+
+        // The two phrases come from independent `generate_keypair` calls
+        // and must be distinct. A regression where one field accidentally
+        // copies the other (e.g. a typo'd clone) would collapse them into
+        // equality and this assertion catches it.
+        assert_ne!(
+            result.coldkey_mnemonic, result.hotkey_mnemonic,
+            "coldkey and hotkey mnemonics must be distinct"
+        );
+
+        // Round-trip: re-derive both keypairs from the returned phrases
+        // and confirm the resulting ss58 addresses match the ones the
+        // command reported. This is the acceptance criterion from issue
+        // #78 — it proves the returned phrases are the phrases actually
+        // used to generate the on-disk keys, not unrelated filler.
+        let (cold_pair, _cold_phrase, _cold_seed) =
+            recover_keypair(Some(&result.coldkey_mnemonic), None)
+                .expect("coldkey mnemonic should re-derive");
+        assert_eq!(
+            cold_pair.public().to_ss58check(),
+            result.coldkey_ss58,
+            "coldkey mnemonic must re-derive to the reported coldkey ss58"
+        );
+        let (hot_pair, _hot_phrase, _hot_seed) =
+            recover_keypair(Some(&result.hotkey_mnemonic), None)
+                .expect("hotkey mnemonic should re-derive");
+        assert_eq!(
+            hot_pair.public().to_ss58check(),
+            result.hotkey_ss58,
+            "hotkey mnemonic must re-derive to the reported hotkey ss58"
+        );
     }
 
     // -- TAO/RAO conversion tests --
@@ -2979,8 +3040,12 @@ mod tests {
             "force must yield a fresh hotkey"
         );
         assert_ne!(
-            first.mnemonic, second.mnemonic,
-            "force must yield a fresh mnemonic"
+            first.coldkey_mnemonic, second.coldkey_mnemonic,
+            "force must yield a fresh coldkey mnemonic"
+        );
+        assert_ne!(
+            first.hotkey_mnemonic, second.hotkey_mnemonic,
+            "force must yield a fresh hotkey mnemonic"
         );
         assert!(second.coldkey_ss58.starts_with('5'));
         assert!(second.hotkey_ss58.starts_with('5'));
@@ -3033,7 +3098,7 @@ mod tests {
         // Regenerate the coldkey from the mnemonic. The wallet dir already
         // holds a `coldkey` file from `create` above, so we must pass
         // force=true or the guard would (correctly) refuse.
-        let regen = regen_coldkey(wallet_name, Some(&cr.mnemonic), None, password, true)
+        let regen = regen_coldkey(wallet_name, Some(&cr.coldkey_mnemonic), None, password, true)
             .expect("regen should work");
         assert_eq!(regen.ss58_address, cr.coldkey_ss58);
 


### PR DESCRIPTION
Closes #78.

## Breaking change

`btt wallet create` now emits BOTH the coldkey and hotkey mnemonics in
its JSON response envelope. The single `mnemonic` field is gone; it has
been replaced by two separate fields, `coldkey_mnemonic` and
`hotkey_mnemonic`. Scripts that parsed `data.mnemonic` from the pre-#78
shape will need to update to read `data.coldkey_mnemonic`.

### Old shape

```json
{
  "ok": true,
  "data": {
    "wallet_name": "alice",
    "coldkey_ss58": "5...",
    "hotkey_ss58": "5...",
    "mnemonic": "<coldkey phrase>"
  }
}
```

### New shape

```json
{
  "ok": true,
  "data": {
    "wallet_name": "alice",
    "coldkey_ss58": "5...",
    "hotkey_ss58": "5...",
    "coldkey_mnemonic": "<coldkey phrase>",
    "hotkey_mnemonic": "<hotkey phrase>"
  }
}
```

## Rationale

Before this change, the hotkey phrase was generated inside
`create_into_staging`, embedded in the on-disk hotkey JSON file, and
then zeroized before the function returned. An automation caller that
captured stdout had no way to recover the hotkey phrase without also
re-reading `<wallet>/hotkeys/<name>` from disk. Per the
`btt-json-output` kendb principle ("mnemonics always shown on create"),
both mnemonics should flow out through stdout. This PR brings actual
behavior into alignment with the stated principle.

btt is pre-1.0 with no output-shape contract yet. Keeping `mnemonic` as
an alias for `coldkey_mnemonic` would compound the confusion that
prompted issue #78 — readers would have to know which "mnemonic" they
were looking at. Breaking cleanly once is less painful than a permanent
backwards-compat escape hatch. Only `wallet create` is affected;
`new-coldkey`, `new-hotkey`, and the regen paths remain unchanged.

## Implementation notes

- `CreateResult` renames `mnemonic` → `coldkey_mnemonic` and adds
  `hotkey_mnemonic`.
- `CreateResult` now derives `Zeroize + ZeroizeOnDrop`. The returned
  phrases are scrubbed from the heap the moment `main.rs` drops the
  value after `print_success`. This closes a latent gap: the pre-#78
  `mnemonic_out` clone was itself never zeroized by the caller.
- `create_into_staging` clones BOTH phrases into the result before
  zeroizing `cold_phrase` / `hot_phrase` / seeds. The pre-clone
  zeroization discipline is unchanged.
- `main.rs` did not need changes — it already calls
  `wallet_keys::create` and passes the result straight to
  `print_success`, which serializes by reference.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test wallet_keys` — 72 passed, 1 ignored, 0 failed
- [x] `create_wallet_roundtrip` unit test expanded to assert:
  - both phrases are 12-word BIP39 mnemonics
  - the two phrases are distinct (guards against an accidental
    one-field-copies-the-other regression)
  - both phrases re-derive via `recover_keypair` to the ss58 addresses
    reported by `create` (the explicit #78 acceptance criterion)
- [x] `wallet_create_force_replaces_existing` updated to assert fresh
  coldkey AND hotkey mnemonics on the `--force` path
- [x] `regen_coldkey_from_mnemonic` updated to read
  `cr.coldkey_mnemonic`

## Real-target verification

`wallet create` does not touch a chain, so the real-target gate is
running the release binary against a tmpfs-scoped wallet dir and
confirming both returned mnemonics round-trip through btt's own regen
subcommands to the exact ss58s reported by `create`.

Steps (executed on the cryptid host):

1. `cargo build --release`
2. `wallet create --name pr78-test-c --password-file <tmpfs pw>` under
   `XDG_CONFIG_HOME=<tmpfs xdg>`
3. Parse the returned JSON; verify both `coldkey_mnemonic` and
   `hotkey_mnemonic` are present and are 12-word phrases
4. `wallet regen-hotkey --mnemonic <hotkey_mnemonic>` into a scratch
   wallet and compare the regenerated ss58 to `hotkey_ss58` from step 2
5. `wallet regen-coldkey --mnemonic <coldkey_mnemonic>` into a scratch
   wallet and compare the regenerated ss58 to `coldkey_ss58` from
   step 2

Observed output (mnemonics redacted):

```
ok=True
wallet_name=pr78-test-c
coldkey_ss58=5FCup9BucZyeTuayU6racbYeMPyXmU99UvFbRv11Gtd7pRET
hotkey_ss58=5FRdLTaxMgbfP7RsMU9LoLhz7shu4kMXj76rZzhJenAw2Q5e
coldkey_mnemonic=<REDACTED 12 words>
hotkey_mnemonic=<REDACTED 12 words>
mnemonics_distinct=True
fields=['coldkey_mnemonic', 'coldkey_ss58', 'hotkey_mnemonic', 'hotkey_ss58', 'wallet_name']
legacy_mnemonic_field_present=False
```

Roundtrip:

```
regen_hotkey_ss58=5FRdLTaxMgbfP7RsMU9LoLhz7shu4kMXj76rZzhJenAw2Q5e
create_hotkey_ss58=5FRdLTaxMgbfP7RsMU9LoLhz7shu4kMXj76rZzhJenAw2Q5e
hotkey_mnemonic_roundtrips=True
regen_coldkey_ss58=5FCup9BucZyeTuayU6racbYeMPyXmU99UvFbRv11Gtd7pRET
create_coldkey_ss58=5FCup9BucZyeTuayU6racbYeMPyXmU99UvFbRv11Gtd7pRET
coldkey_mnemonic_roundtrips=True
```

Both phrases re-derive to the expected ss58s on the release binary.

## Docs

README updated in two places:

- command-table row for `wallet create` now says "print both coldkey +
  hotkey mnemonics"
- prose paragraph below the command list calls out the new shape
  explicitly and flags it as a breaking change from pre-#78