### PR TITLE
subnet: add `subnet hyperparameters --netuid <N>` (#77 phase 1, fourth of four — closes phase 1)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,21 @@ pub enum SubnetAction {
         #[arg(long)]
         netuid: u16,
     },
+
+    /// Dump the full hyperparameter set of a given subnet.
+    ///
+    /// Reads `SubnetInfoRuntimeApi::get_subnet_hyperparams(netuid)` on
+    /// the head block and returns all 27 runtime hyperparameter fields
+    /// (rho, kappa, tempo, immunity_period, min/max_allowed_weights,
+    /// min/max_burn, min/max_difficulty, adjustment_alpha, commit-
+    /// reveal settings, liquid alpha, etc.). Read-only; no wallet,
+    /// no signing, no extrinsic. Exits with a structured error if
+    /// the netuid does not exist on chain.
+    Hyperparameters {
+        /// Subnet id to dump the hyperparameters for.
+        #[arg(long)]
+        netuid: u16,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/subnet.rs
+++ b/src/commands/subnet.rs
@@ -1,12 +1,11 @@
-// Subnet commands. Phase 1 (issue #77) is read-only.
-//
-// Ships so far: `lock-cost` (PR #91), `list` (PR #92), `metagraph`
-// (this PR). Remaining phase-1 command: `hyperparameters --netuid
-// <N>`. All four call into `SubnetInfoRuntimeApi` / `SubnetRegistration
-// RuntimeApi` — pure runtime state queries, no extrinsics, no wallet
-// material, no trust-sensitive surface. Phase 2 of issue #77 is
-// reserved for write commands (`subnet register`, `subnet create`,
-// etc.) and will be its own issue + PRs.
+// Subnet commands. Phase 1 (issue #77) is read-only. All four
+// commands land now: `lock-cost` (PR #91), `list` (PR #92),
+// `metagraph` (PR #94), `hyperparameters` (this PR). They call into
+// `SubnetInfoRuntimeApi` / `SubnetRegistrationRuntimeApi` — pure
+// runtime state queries, no extrinsics, no wallet material, no
+// trust-sensitive surface. Phase 2 of issue #77 is reserved for
+// write commands (`subnet register`, `subnet create`, etc.) and will
+// be its own issue + PRs.
 
 use std::time::Duration;
 
@@ -568,6 +567,158 @@ fn decode_compact_u8_vec<C: Clone>(composite: &Value<C>, field: &str) -> Option<
         bytes.push(b as u8);
     }
     Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+// ── hyperparameters ────────────────────────────────────────────────
+
+/// Full subnet hyperparameter dump returned by `btt subnet hyperparameters --netuid <N>`.
+///
+/// This is the 27-field upstream `SubnetHyperparams` struct
+/// (`pallets/subtensor/src/rpc_info/subnet_info.rs`), surfaced
+/// one-for-one. Unlike `subnet list`, where we curate down from 18
+/// upstream fields to 9 display fields, a hyperparameters dump is
+/// inherently a full dump — users running this command want to see
+/// the complete runtime configuration of a subnet, not a tasteful
+/// subset. The one transformation we apply is stringifying balances
+/// (`min_burn`, `max_burn`) for JSON parser safety.
+#[derive(Serialize, Debug)]
+pub struct SubnetHyperparamsInfo {
+    pub netuid: u16,
+    pub rho: u16,
+    pub kappa: u16,
+    pub immunity_period: u16,
+    pub min_allowed_weights: u16,
+    pub max_weights_limit: u16,
+    pub tempo: u16,
+    pub min_difficulty: u64,
+    pub max_difficulty: u64,
+    pub weights_version: u64,
+    pub weights_rate_limit: u64,
+    pub adjustment_interval: u16,
+    pub activity_cutoff: u16,
+    pub registration_allowed: bool,
+    pub target_regs_per_interval: u16,
+    pub min_burn_rao: String,
+    pub max_burn_rao: String,
+    pub bonds_moving_avg: u64,
+    pub max_regs_per_block: u16,
+    pub serving_rate_limit: u64,
+    pub max_validators: u16,
+    pub adjustment_alpha: u64,
+    pub difficulty: u64,
+    pub commit_reveal_period: u64,
+    pub commit_reveal_weights_enabled: bool,
+    pub alpha_high: u16,
+    pub alpha_low: u16,
+    pub liquid_alpha_enabled: bool,
+    /// Block number at which the hyperparameters were queried.
+    pub at_block: u64,
+}
+
+/// Query the hyperparameters of a subnet via
+/// `SubnetInfoRuntimeApi::get_subnet_hyperparams(netuid)`. Returns
+/// `None` from the runtime if the netuid does not exist; btt
+/// translates that to a structured `QUERY_FAILED` error.
+pub async fn hyperparameters(
+    endpoint: &str,
+    netuid: u16,
+) -> Result<SubnetHyperparamsInfo, BttError> {
+    let api = rpc::connect(endpoint).await?;
+
+    let at_block = tokio::time::timeout(RPC_TIMEOUT, api.at_current_block())
+        .await
+        .map_err(|_| BttError::query("at_current_block() timed out"))?
+        .map_err(|e| BttError::query(format!("failed to resolve client at head: {e}")))?;
+
+    let block_number: u64 = at_block.block_number();
+
+    let call = subxt::dynamic::runtime_api_call::<Vec<SValue>, SValue>(
+        "SubnetInfoRuntimeApi",
+        "get_subnet_hyperparams",
+        vec![SValue::u128(netuid as u128)],
+    );
+
+    let value = tokio::time::timeout(RPC_TIMEOUT, at_block.runtime_apis().call(call))
+        .await
+        .map_err(|_| BttError::query("get_subnet_hyperparams timed out"))?
+        .map_err(|e| {
+            BttError::query(format!("get_subnet_hyperparams runtime call failed: {e}"))
+        })?;
+
+    // `Option<SubnetHyperparams>` — None means the netuid does not
+    // exist on chain. Peel the Option via .at(0).
+    let hp = value.at(0).ok_or_else(|| {
+        BttError::query(format!("netuid {netuid} not found on chain"))
+    })?;
+
+    parse_hyperparams(hp, netuid, block_number)
+}
+
+fn parse_hyperparams<C: Clone>(
+    hp: &Value<C>,
+    netuid: u16,
+    at_block: u64,
+) -> Result<SubnetHyperparamsInfo, BttError> {
+    // Upstream `SubnetHyperparams` does NOT carry a `netuid` field —
+    // the netuid is an argument to `get_subnet_hyperparams`, not part
+    // of the return shape. We echo it back in the output envelope
+    // anyway so the JSON is self-describing.
+    let u16_field = |name: &'static str| -> Result<u16, BttError> {
+        compact_u16(hp, name).ok_or_else(|| {
+            BttError::parse(format!("hyperparameters[netuid={netuid}]: missing {name}"))
+        })
+    };
+    let u64_field = |name: &'static str| -> Result<u64, BttError> {
+        compact_u64(hp, name).ok_or_else(|| {
+            BttError::parse(format!("hyperparameters[netuid={netuid}]: missing {name}"))
+        })
+    };
+    let u128_field = |name: &'static str| -> Result<u128, BttError> {
+        compact_u128(hp, name).ok_or_else(|| {
+            BttError::parse(format!("hyperparameters[netuid={netuid}]: missing {name}"))
+        })
+    };
+    let bool_field = |name: &'static str| -> Result<bool, BttError> {
+        hp.at(name)
+            .and_then(|v| v.as_bool())
+            .ok_or_else(|| {
+                BttError::parse(format!(
+                    "hyperparameters[netuid={netuid}]: missing or non-bool {name}"
+                ))
+            })
+    };
+
+    Ok(SubnetHyperparamsInfo {
+        netuid,
+        rho: u16_field("rho")?,
+        kappa: u16_field("kappa")?,
+        immunity_period: u16_field("immunity_period")?,
+        min_allowed_weights: u16_field("min_allowed_weights")?,
+        max_weights_limit: u16_field("max_weights_limit")?,
+        tempo: u16_field("tempo")?,
+        min_difficulty: u64_field("min_difficulty")?,
+        max_difficulty: u64_field("max_difficulty")?,
+        weights_version: u64_field("weights_version")?,
+        weights_rate_limit: u64_field("weights_rate_limit")?,
+        adjustment_interval: u16_field("adjustment_interval")?,
+        activity_cutoff: u16_field("activity_cutoff")?,
+        registration_allowed: bool_field("registration_allowed")?,
+        target_regs_per_interval: u16_field("target_regs_per_interval")?,
+        min_burn_rao: u128_field("min_burn")?.to_string(),
+        max_burn_rao: u128_field("max_burn")?.to_string(),
+        bonds_moving_avg: u64_field("bonds_moving_avg")?,
+        max_regs_per_block: u16_field("max_regs_per_block")?,
+        serving_rate_limit: u64_field("serving_rate_limit")?,
+        max_validators: u16_field("max_validators")?,
+        adjustment_alpha: u64_field("adjustment_alpha")?,
+        difficulty: u64_field("difficulty")?,
+        commit_reveal_period: u64_field("commit_reveal_period")?,
+        commit_reveal_weights_enabled: bool_field("commit_reveal_weights_enabled")?,
+        alpha_high: u16_field("alpha_high")?,
+        alpha_low: u16_field("alpha_low")?,
+        liquid_alpha_enabled: bool_field("liquid_alpha_enabled")?,
+        at_block,
+    })
 }
 
 // ── per-UID vec walkers ───────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,11 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                         commands::subnet::metagraph(&endpoint, netuid).await?;
                     output::print_success(&result, pretty);
                 }
+                SubnetAction::Hyperparameters { netuid } => {
+                    let result =
+                        commands::subnet::hyperparameters(&endpoint, netuid).await?;
+                    output::print_success(&result, pretty);
+                }
             }
         }
         Command::Skill => {


### PR DESCRIPTION
[cryptid] Fourth and final PR for issue #77 phase 1. Ships `btt subnet hyperparameters --netuid <N>`, dumping all 27 runtime hyperparameter fields of a given subnet via `SubnetInfoRuntimeApi::get_subnet_hyperparams`. **This PR closes phase 1 of #77.**

## Output shape

All 27 upstream `SubnetHyperparams` fields, one-for-one:

```json
{"ok":true,"data":{
    "netuid":1,
    "rho":10,"kappa":32767,"immunity_period":0,
    "min_allowed_weights":1,"max_weights_limit":65535,"tempo":99,
    "min_difficulty":10000000,"max_difficulty":4611686018427387903,
    "weights_version":0,"weights_rate_limit":100,
    "adjustment_interval":100,"activity_cutoff":5000,
    "registration_allowed":true,"target_regs_per_interval":2,
    "min_burn_rao":"500000","max_burn_rao":"100000000000",
    "bonds_moving_avg":900000,"max_regs_per_block":1,
    "serving_rate_limit":50,"max_validators":128,
    "adjustment_alpha":0,"difficulty":10000000,
    "commit_reveal_period":1,"commit_reveal_weights_enabled":true,
    "alpha_high":58982,"alpha_low":45875,"liquid_alpha_enabled":false,
    "at_block":6914264
}}
```

Unlike `subnet list` which curates 9 display fields out of 18, a hyperparameters dump is inherently a full dump — users running this command want to see the complete runtime config. Only transformation: `min_burn` / `max_burn` stringified as `min_burn_rao` / `max_burn_rao` (TaoBalance can exceed JS safe-integer range).

## Real-target verification (per 2026-04-15 done gate)

```
$ ./target/release/btt subnet hyperparameters --netuid 1 --network test
```

**testnet block 6914264**. All 27 fields decoded. Values cross-check against the subnet-scoped fields from PR #94's `subnet metagraph --netuid 1` dump (rho=10, kappa=32767, tempo=99, etc.). No decoder errors, no missing fields.

## Local gates

- `cargo check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo build --release`: clean
- Real-target testnet run: success (above)

## Implementation notes

- Runtime API: `SubnetInfoRuntimeApi::get_subnet_hyperparams(netuid)`
- No per-UID arrays, so no parallel-Vec zip. Straight composite walk via local closures (`u16_field`, `u64_field`, `u128_field`, `bool_field`) that keep the 27 field extractions to one line per field.
- Reuses `compact_u16` / `compact_u64` / `compact_u128` helpers from prior subnet PRs. Only new `Value` method used is `.as_bool()` for the three plain-bool fields.
- `SubnetAction::Hyperparameters { netuid: u16 }` wired into `main.rs`.

## No dep changes

No new direct or transitive deps.

## Phase 1 complete

Phase 1 of #77 is fully merged after this PR:

| PR | Command | Runtime API |
|---|---|---|
| #91 | `subnet lock-cost` | `SubnetRegistrationRuntimeApi::get_network_registration_cost` |
| #92 | `subnet list` | `SubnetInfoRuntimeApi::get_subnets_info` |
| #94 | `subnet metagraph --netuid <N>` | `SubnetInfoRuntimeApi::get_metagraph` |
| #95 (this) | `subnet hyperparameters --netuid <N>` | `SubnetInfoRuntimeApi::get_subnet_hyperparams` |

## Follow-ups

- #93: consolidate the 14 decoder helpers duplicated across `stake.rs` and `subnet.rs` into a shared `src/commands/dynamic_decode.rs` module. Pure refactor, picked up now that phase 1 is closed.
- Phase 2 (write commands: `register`, `create`, `set_identity`): to be tracked in a new issue.
