### PR TITLE
wallet: move regen-* `--mnemonic` / `--seed` mutex to clap layer (closes #88)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -210,10 +210,12 @@ pub enum WalletAction {
         /// Wallet name
         #[arg(long)]
         name: String,
-        /// BIP39 mnemonic phrase
-        #[arg(long)]
+        /// BIP39 mnemonic phrase. Mutually exclusive with `--seed`; exactly
+        /// one of the two must be provided.
+        #[arg(long, conflicts_with = "seed")]
         mnemonic: Option<String>,
-        /// Hex-encoded seed (0x...)
+        /// Hex-encoded seed (0x...). Mutually exclusive with `--mnemonic`;
+        /// exactly one of the two must be provided.
         #[arg(long)]
         seed: Option<String>,
         /// Read coldkey password from file at <path>. For non-interactive
@@ -242,10 +244,12 @@ pub enum WalletAction {
         /// Hotkey name
         #[arg(long, default_value = "default")]
         hotkey: String,
-        /// BIP39 mnemonic phrase
-        #[arg(long)]
+        /// BIP39 mnemonic phrase. Mutually exclusive with `--seed`; exactly
+        /// one of the two must be provided.
+        #[arg(long, conflicts_with = "seed")]
         mnemonic: Option<String>,
-        /// Hex-encoded seed (0x...)
+        /// Hex-encoded seed (0x...). Mutually exclusive with `--mnemonic`;
+        /// exactly one of the two must be provided.
         #[arg(long)]
         seed: Option<String>,
         /// Overwrite an existing hotkey file if one is present. Without

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -1347,6 +1347,15 @@ fn generate_keypair(_n_words: u32) -> Result<(Pair, String, [u8; 32]), BttError>
 }
 
 /// Recover a keypair from either a mnemonic phrase or a hex seed.
+///
+/// `--mnemonic` and `--seed` are mutually exclusive at the clap parse
+/// layer (see `src/cli.rs` — `mnemonic` carries `conflicts_with =
+/// "seed"` on both `RegenColdkey` and `RegenHotkey`), so the
+/// `(Some, Some)` case is unreachable from the public CLI and is
+/// asserted via `unreachable!` here for defense-in-depth against
+/// future direct callers. The `(None, None)` case is still reachable
+/// — clap does not require at least one of the two, so we still
+/// return a structured error naming both flags.
 fn recover_keypair(
     mnemonic: Option<&str>,
     seed_hex: Option<&str>,
@@ -1371,9 +1380,18 @@ fn recover_keypair(
             let pair = Pair::from_seed(&seed);
             Ok((pair, String::new(), seed))
         }
-        (Some(_), Some(_)) => Err(BttError::invalid_input(
-            "provide either --mnemonic or --seed, not both",
-        )),
+        (Some(_), Some(_)) => {
+            // Clap's `conflicts_with = "seed"` on the `--mnemonic`
+            // arg rejects this at parse time for both regen
+            // subcommands. If we ever land here it means either a
+            // direct test-only caller bypassed clap, or the
+            // conflicts_with attribute was removed — either way
+            // it's a bug worth panicking on, not a silent accept.
+            unreachable!(
+                "recover_keypair called with both mnemonic and seed — \
+                 clap conflicts_with should have rejected this at parse"
+            )
+        }
         (None, None) => Err(BttError::invalid_input(
             "provide either --mnemonic or --seed",
         )),


### PR DESCRIPTION
[cryptid] Closes #88.

## Problem

`wallet regen-coldkey` and `wallet regen-hotkey` accepted `--mnemonic` and `--seed` as mutually exclusive, but the exclusion was enforced at runtime in `recover_keypair`'s match. Users got a `{ok:false,error:...}` JSON envelope instead of the standard clap `"cannot be used with"` rejection.

## Fix

Add `conflicts_with = "seed"` to the `--mnemonic` arg on both `RegenColdkey` and `RegenHotkey` in `src/cli.rs`. The runtime `(Some(_), Some(_))` arm in `recover_keypair` is now unreachable and is replaced with `unreachable!()` naming the clap invariant — defense-in-depth against future direct (test-only) callers that might bypass clap.

The `(None, None)` arm stays. Clap's `conflicts_with` does not require at least one of the two, so a no-flags invocation is still possible and still returns a structured "provide either --mnemonic or --seed" error.

## Real-target proof

```
$ btt wallet regen-coldkey --name x --mnemonic "..." --seed 0xdeadbeef
error: the argument '--mnemonic <MNEMONIC>' cannot be used with '--seed <SEED>'

Usage: btt wallet regen-coldkey --name <NAME> --mnemonic <MNEMONIC>

For more information, try '--help'.
[exit 2]

$ btt wallet regen-hotkey --name x --mnemonic "..." --seed 0xdeadbeef
error: the argument '--mnemonic <MNEMONIC>' cannot be used with '--seed <SEED>'
[exit 2]
```

Exit code 2 is clap's argument-parsing convention, distinct from btt's exit 1 for runtime structured errors. Consumers that switch on exit code to distinguish argument errors from runtime failures now get the right signal.

## Acceptance (from issue)

- [x] `btt wallet regen-coldkey --mnemonic "..." --seed 0x...` fails at clap layer with "cannot be used with"
- [x] `--mnemonic` alone still works. `--seed` alone still works.
- [x] Runtime validation branch removed (now `unreachable!()`).
- [x] Unit tests exercise each single-flag path (pre-existing `mnemonic_recovery_roundtrip`, `seed_recovery_roundtrip` — both pass post-change).

## Local gates

- `cargo check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test recovery`: 2 passed
- `cargo build --release`: clean
- Real-target clap rejection run: both subcommands reject with exit 2

## No dep changes

Zero new deps. 2 files touched, +31/-9.

Surfaced by the PR #82 barbarian during README refresh review. Closes #88.
