### PR TITLE
wallet: clap-level seed format validation for regen-* `--seed` (closes #87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,21 @@ btt wallet new-coldkey --name alice [--n-words 12|24] \
 btt wallet new-hotkey --name alice [--hotkey validator] \
                       [--n-words 12|24] [--force]
 
-# Restore a coldkey from mnemonic or seed (exactly one of --mnemonic / --seed).
+# Restore a coldkey from mnemonic or seed (exactly one of --mnemonic / --seed,
+# enforced at the clap parse layer). --seed is a 32-byte sr25519 seed
+# encoded as `0x` + 64 hex characters (66 characters total); anything else
+# is rejected at parse time with a clear error.
 btt wallet regen-coldkey --name alice \
     --mnemonic "word1 word2 ... word12" \
     [--password-file <path>] [--force]
-btt wallet regen-coldkey --name alice --seed 0x<hex> \
+btt wallet regen-coldkey --name alice --seed 0x<64 hex chars> \
     [--password-file <path>] [--force]
 
-# Restore a hotkey from mnemonic or seed (exactly one of --mnemonic / --seed).
+# Restore a hotkey from mnemonic or seed. Same --seed format: 0x + 64 hex.
 btt wallet regen-hotkey --name alice [--hotkey default] \
     --mnemonic "word1 word2 ... word12" [--force]
 btt wallet regen-hotkey --name alice [--hotkey default] \
-    --seed 0x<hex> [--force]
+    --seed 0x<64 hex chars> [--force]
 
 # Sign a message with the wallet's coldkey (default).
 btt wallet sign --name alice --message "hello" [--password-file <path>]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,50 @@
 use clap::{Parser, Subcommand};
 
+/// Clap `value_parser` for the `--seed` flag on `wallet regen-coldkey`
+/// and `wallet regen-hotkey`.
+///
+/// The subtensor sr25519 seed is 32 bytes, conventionally encoded as a
+/// `0x`-prefixed 64-character lowercase hex string (66 characters
+/// total). This parser rejects anything else at clap parse time so the
+/// user gets a clear, actionable error before the key-decryption path
+/// runs.
+///
+/// Accepts: `0x` prefix + exactly 64 hex digits (case-insensitive).
+///
+/// Rejects:
+/// - missing `0x` prefix
+/// - wrong length (not exactly 66 chars including prefix, i.e. not
+///   exactly 64 hex digits after the prefix)
+/// - non-hex characters
+///
+/// Returns the input string unchanged on success. The downstream
+/// `recover_keypair` path still runs `hex::decode` and a
+/// `len == 32` check as a defense-in-depth backstop against any
+/// future caller that bypasses clap. This parser is the primary UX
+/// gate; the runtime check is the correctness gate.
+pub fn parse_seed_hex(s: &str) -> Result<String, String> {
+    let stripped = s.strip_prefix("0x").ok_or_else(|| {
+        format!(
+            "seed must start with `0x` and be followed by exactly 64 hex characters \
+             (32-byte sr25519 seed); got `{s}`"
+        )
+    })?;
+    if stripped.len() != 64 {
+        return Err(format!(
+            "seed must be exactly 64 hex characters after the `0x` prefix \
+             (32-byte sr25519 seed); got {} characters",
+            stripped.len()
+        ));
+    }
+    if !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "seed must contain only hex characters [0-9a-fA-F] after the `0x` \
+             prefix; got `{s}`"
+        ));
+    }
+    Ok(s.to_string())
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "btt", version, about = "Minimal, secure Bittensor CLI")]
 pub struct Cli {
@@ -214,9 +259,11 @@ pub enum WalletAction {
         /// one of the two must be provided.
         #[arg(long, conflicts_with = "seed")]
         mnemonic: Option<String>,
-        /// Hex-encoded seed (0x...). Mutually exclusive with `--mnemonic`;
-        /// exactly one of the two must be provided.
-        #[arg(long)]
+        /// 32-byte sr25519 seed encoded as `0x` + 64 hex characters (66
+        /// characters total). Mutually exclusive with `--mnemonic`;
+        /// exactly one of the two must be provided. Clap rejects
+        /// non-conforming input at parse time.
+        #[arg(long, value_parser = parse_seed_hex)]
         seed: Option<String>,
         /// Read coldkey password from file at <path>. For non-interactive
         /// automation only. The file's first line (up to but not including
@@ -248,9 +295,11 @@ pub enum WalletAction {
         /// one of the two must be provided.
         #[arg(long, conflicts_with = "seed")]
         mnemonic: Option<String>,
-        /// Hex-encoded seed (0x...). Mutually exclusive with `--mnemonic`;
-        /// exactly one of the two must be provided.
-        #[arg(long)]
+        /// 32-byte sr25519 seed encoded as `0x` + 64 hex characters (66
+        /// characters total). Mutually exclusive with `--mnemonic`;
+        /// exactly one of the two must be provided. Clap rejects
+        /// non-conforming input at parse time.
+        #[arg(long, value_parser = parse_seed_hex)]
         seed: Option<String>,
         /// Overwrite an existing hotkey file if one is present. Without
         /// this flag, the command refuses to run when the target key file
@@ -402,4 +451,84 @@ pub enum StakeAction {
         #[arg(long, default_value_t = false)]
         all: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_seed_hex;
+
+    // Issue #87: clap-level `parse_seed_hex` rejects non-conforming input
+    // with clear messages. Accepts only `0x` + 64 hex chars.
+
+    #[test]
+    fn parse_seed_accepts_valid_64_hex_with_prefix() {
+        let seed = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        let parsed = parse_seed_hex(seed).expect("32-byte zero seed should parse");
+        assert_eq!(parsed, seed);
+    }
+
+    #[test]
+    fn parse_seed_accepts_mixed_case_hex() {
+        let seed = "0xDeadBeefCafeBabe0123456789aBcDeF0123456789ABCDEF0123456789abcdef";
+        let parsed = parse_seed_hex(seed).expect("mixed-case hex should parse");
+        assert_eq!(parsed, seed);
+    }
+
+    #[test]
+    fn parse_seed_rejects_missing_0x_prefix() {
+        let err = parse_seed_hex(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .expect_err("missing prefix must be rejected");
+        assert!(err.contains("`0x`"), "error should name the 0x prefix: {err}");
+    }
+
+    #[test]
+    fn parse_seed_rejects_too_short() {
+        // 0x + 62 hex chars = 64 total, 2 short.
+        let err = parse_seed_hex(
+            "0x00000000000000000000000000000000000000000000000000000000000000",
+        )
+        .expect_err("too short must be rejected");
+        assert!(
+            err.contains("exactly 64 hex characters"),
+            "error should name the length: {err}"
+        );
+        assert!(err.contains("62"), "error should report the actual length: {err}");
+    }
+
+    #[test]
+    fn parse_seed_rejects_too_long() {
+        // 0x + 66 hex chars, 2 over.
+        let err = parse_seed_hex(
+            "0x000000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .expect_err("too long must be rejected");
+        assert!(err.contains("exactly 64 hex characters"), "got {err}");
+        assert!(err.contains("66"), "error should report the actual length: {err}");
+    }
+
+    #[test]
+    fn parse_seed_rejects_non_hex_characters() {
+        // 63 zeros + 1 'z' — right length, wrong charset.
+        let err = parse_seed_hex(
+            "0x000000000000000000000000000000000000000000000000000000000000000z",
+        )
+        .expect_err("non-hex must be rejected");
+        assert!(
+            err.contains("only hex characters"),
+            "error should name the charset: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_seed_rejects_empty_string() {
+        assert!(parse_seed_hex("").is_err());
+    }
+
+    #[test]
+    fn parse_seed_rejects_just_prefix() {
+        let err = parse_seed_hex("0x").expect_err("0x alone must be rejected");
+        assert!(err.contains("exactly 64"), "got {err}");
+    }
 }


### PR DESCRIPTION
[cryptid] Closes #87.

## Problem

`--seed` on `wallet regen-coldkey` and `wallet regen-hotkey` had an unstated length contract. Users had no way to know from `--help` or the README what format was expected beyond "hex". Non-conforming input was rejected at runtime with a terse error. Correct but opaque.

## Fix

`src/cli.rs` gains `pub fn parse_seed_hex(s: &str) -> Result<String, String>` as a clap `value_parser`. It enforces:

- `0x` prefix required
- exactly 64 hex characters after the prefix
- only `[0-9a-fA-F]` after the prefix

Attached via `#[arg(long, value_parser = parse_seed_hex)]` to `seed` on both `RegenColdkey` and `RegenHotkey`. Clap rejects non-conforming input at parse time with exit code 2, naming exactly what's wrong.

The downstream `recover_keypair` path still runs `hex::decode` + `len == 32` as a defense-in-depth backstop.

## Real-target proof

```
$ btt wallet regen-hotkey --name x --seed 0x0000...0000   # valid
[proceeds past clap]

$ btt wallet regen-hotkey --name x --seed 0000...0000     # no 0x
error: ... seed must start with `0x` and be followed by exactly 64 hex characters ...

$ btt wallet regen-hotkey --name x --seed 0xdeadbeef      # too short
error: ... seed must be exactly 64 hex characters after the `0x` prefix ... got 8 characters

$ btt wallet regen-hotkey --name x --seed 0xzzzz000000...  # non-hex
error: ... seed must contain only hex characters [0-9a-fA-F] ...
```

Each rejection names exactly what's wrong. All failures hit clap before any runtime code runs.

## Unit tests

8 tests in `src/cli::tests`:

- `parse_seed_accepts_valid_64_hex_with_prefix`
- `parse_seed_accepts_mixed_case_hex`
- `parse_seed_rejects_missing_0x_prefix`
- `parse_seed_rejects_too_short`
- `parse_seed_rejects_too_long`
- `parse_seed_rejects_non_hex_characters`
- `parse_seed_rejects_empty_string`
- `parse_seed_rejects_just_prefix`

All 8 pass.

## README

Updated the regen-coldkey and regen-hotkey usage blocks to call out the format: `0x + 64 hex characters (66 characters total)`.

## Acceptance (from issue #87)

- [x] `btt wallet regen-coldkey --seed notahex ...` fails with a clap error naming the expected format
- [x] `btt wallet regen-coldkey --seed 0x<64 hex chars> ...` still succeeds
- [x] README's regen-* entries note the format
- [x] `--help` for `--seed` documents the format via the updated doc comment

## Local gates

- `cargo check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test parse_seed`: 8 passed
- `cargo build --release`: clean
- Real-target clap rejection: all 4 cases behave correctly

## No dep changes

Zero new deps. 2 files touched, +142/-10.

Surfaced by the PR #82 barbarian. Closes #87.
