### PR TITLE
wallet identity: get-identity and set-identity

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -378,6 +378,50 @@ pub enum WalletAction {
         ss58: String,
     },
 
+    /// Query on-chain identity for an SS58 address.
+    ///
+    /// Reads `SubtensorModule::Identities` storage map. Returns name,
+    /// URL, description, image, discord, github repo, and github
+    /// username. Empty strings for unset fields. Read-only; no wallet,
+    /// no signing, no extrinsic.
+    GetIdentity {
+        /// SS58 address to query
+        #[arg(long)]
+        ss58: String,
+    },
+
+    /// Set on-chain identity for this wallet's coldkey.
+    ///
+    /// Submits a `SubtensorModule::set_identity` extrinsic. Coldkey-
+    /// signing. All fields are optional strings; unset fields are sent
+    /// as empty strings.
+    SetIdentity {
+        /// Wallet name (coldkey used for signing)
+        #[arg(long)]
+        name: String,
+        /// Display name
+        #[arg(long, default_value = "")]
+        display_name: String,
+        /// URL
+        #[arg(long, default_value = "")]
+        url: String,
+        /// Description
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Image URL
+        #[arg(long, default_value = "")]
+        image: String,
+        /// Discord handle
+        #[arg(long, default_value = "")]
+        discord: String,
+        /// GitHub repository
+        #[arg(long, default_value = "")]
+        github_repo: String,
+        /// GitHub username
+        #[arg(long, default_value = "")]
+        github_username: String,
+    },
+
     /// Reap stale `.tmp.*`, `.bak.*`, and `.lock.*` entries under the
     /// wallets directory. These are reserved prefixes left behind by
     /// `wallet create` on crashed or interrupted runs (see issue #42).

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -1,0 +1,186 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use sp_core::Pair as PairTrait;
+use subxt::ext::scale_value::Value as SValue;
+
+use crate::commands::chain::parse_ss58;
+use crate::commands::stake::Sr25519Signer;
+use crate::commands::wallet_keys::decrypt_coldkey_interactive;
+use crate::error::BttError;
+use crate::rpc;
+
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Serialize)]
+pub struct IdentityInfo {
+    pub address: String,
+    pub name: String,
+    pub url: String,
+    pub description: String,
+    pub image: String,
+    pub discord: String,
+    pub github_repo: String,
+    pub github_username: String,
+}
+
+fn extract_string_field(val: &SValue, field: &str) -> String {
+    val.at(field)
+        .and_then(|v| {
+            if let SValue::Primitive(subxt::ext::scale_value::Primitive::String(s)) = v {
+                Some(s.clone())
+            } else {
+                v.as_u128().map(|_| String::new())
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn extract_bytes_as_string(val: &SValue, field: &str) -> String {
+    val.at(field)
+        .map(|v| match v {
+            SValue::Primitive(subxt::ext::scale_value::Primitive::String(s)) => s.clone(),
+            _ => {
+                let mut bytes = Vec::new();
+                let mut i = 0u32;
+                while let Some(b) = v.at(i) {
+                    if let Some(n) = b.as_u128() {
+                        bytes.push(n as u8);
+                    }
+                    i += 1;
+                }
+                String::from_utf8(bytes).unwrap_or_default()
+            }
+        })
+        .unwrap_or_default()
+}
+
+pub async fn get_identity(endpoint: &str, address: &str) -> Result<IdentityInfo, BttError> {
+    let account_id_bytes = parse_ss58(address)?;
+
+    let api = rpc::connect(endpoint).await?;
+
+    let storage_query =
+        subxt::dynamic::storage::<Vec<SValue>, SValue>("SubtensorModule", "Identities");
+
+    let at_block = tokio::time::timeout(RPC_TIMEOUT, api.at_current_block())
+        .await
+        .map_err(|_| BttError::query("storage query timed out"))?
+        .map_err(|e| BttError::query(format!("failed to get block: {e}")))?;
+
+    let storage = at_block.storage();
+
+    let result = tokio::time::timeout(
+        RPC_TIMEOUT,
+        storage.try_fetch(&storage_query, vec![SValue::from_bytes(account_id_bytes)]),
+    )
+    .await
+    .map_err(|_| BttError::query("identity fetch timed out"))?
+    .map_err(|e| BttError::query(format!("failed to fetch identity: {e}")))?;
+
+    match result {
+        Some(value) => {
+            let decoded = value
+                .decode()
+                .map_err(|e| BttError::parse(format!("failed to decode identity: {e}")))?;
+
+            Ok(IdentityInfo {
+                address: address.to_string(),
+                name: extract_bytes_as_string(&decoded, "name"),
+                url: extract_bytes_as_string(&decoded, "url"),
+                description: extract_bytes_as_string(&decoded, "description"),
+                image: extract_bytes_as_string(&decoded, "image"),
+                discord: extract_bytes_as_string(&decoded, "discord"),
+                github_repo: extract_bytes_as_string(&decoded, "github_repo"),
+                github_username: extract_bytes_as_string(&decoded, "github_username"),
+            })
+        }
+        None => Ok(IdentityInfo {
+            address: address.to_string(),
+            name: String::new(),
+            url: String::new(),
+            description: String::new(),
+            image: String::new(),
+            discord: String::new(),
+            github_repo: String::new(),
+            github_username: String::new(),
+        }),
+    }
+}
+
+#[derive(Serialize)]
+pub struct SetIdentityResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub address: String,
+    pub name: String,
+}
+
+pub async fn set_identity(
+    endpoint: &str,
+    wallet: &str,
+    name: &str,
+    url: &str,
+    description: &str,
+    image: &str,
+    discord: &str,
+    github_repo: &str,
+    github_username: &str,
+) -> Result<SetIdentityResult, BttError> {
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let from_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "set_identity",
+        vec![
+            SValue::string(name),
+            SValue::string(url),
+            SValue::string(image),
+            SValue::string(discord),
+            SValue::string(description),
+            SValue::string(""),
+            SValue::string(github_repo),
+            SValue::string(github_username),
+        ],
+    );
+
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(SetIdentityResult {
+        tx_hash,
+        block: block_hash,
+        address: from_ss58,
+        name: name.to_string(),
+    })
+}

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -108,16 +108,20 @@ pub struct SetIdentityResult {
     pub name: String,
 }
 
+pub struct SetIdentityFields<'a> {
+    pub display_name: &'a str,
+    pub url: &'a str,
+    pub description: &'a str,
+    pub image: &'a str,
+    pub discord: &'a str,
+    pub github_repo: &'a str,
+    pub github_username: &'a str,
+}
+
 pub async fn set_identity(
     endpoint: &str,
     wallet: &str,
-    name: &str,
-    url: &str,
-    description: &str,
-    image: &str,
-    discord: &str,
-    github_repo: &str,
-    github_username: &str,
+    fields: SetIdentityFields<'_>,
 ) -> Result<SetIdentityResult, BttError> {
     let pair = decrypt_coldkey_interactive(wallet)?;
     let from_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
@@ -129,14 +133,14 @@ pub async fn set_identity(
         "SubtensorModule",
         "set_identity",
         vec![
-            SValue::string(name),
-            SValue::string(url),
-            SValue::string(image),
-            SValue::string(discord),
-            SValue::string(description),
+            SValue::string(fields.display_name),
+            SValue::string(fields.url),
+            SValue::string(fields.image),
+            SValue::string(fields.discord),
+            SValue::string(fields.description),
             SValue::string(""),
-            SValue::string(github_repo),
-            SValue::string(github_username),
+            SValue::string(fields.github_repo),
+            SValue::string(fields.github_username),
         ],
     );
 
@@ -173,6 +177,6 @@ pub async fn set_identity(
         tx_hash,
         block: block_hash,
         address: from_ss58,
-        name: name.to_string(),
+        name: fields.display_name.to_string(),
     })
 }

--- a/src/commands/identity.rs
+++ b/src/commands/identity.rs
@@ -2,9 +2,11 @@ use std::time::Duration;
 
 use serde::Serialize;
 use sp_core::Pair as PairTrait;
+use subxt::dynamic::{At, Value};
 use subxt::ext::scale_value::Value as SValue;
 
 use crate::commands::chain::parse_ss58;
+use crate::commands::dynamic_decode::value_to_u64;
 use crate::commands::stake::Sr25519Signer;
 use crate::commands::wallet_keys::decrypt_coldkey_interactive;
 use crate::error::BttError;
@@ -24,35 +26,25 @@ pub struct IdentityInfo {
     pub github_username: String,
 }
 
-fn extract_string_field(val: &SValue, field: &str) -> String {
-    val.at(field)
-        .and_then(|v| {
-            if let SValue::Primitive(subxt::ext::scale_value::Primitive::String(s)) = v {
-                Some(s.clone())
-            } else {
-                v.as_u128().map(|_| String::new())
+fn value_to_string<C: Clone>(val: &Value<C>) -> String {
+    let mut bytes = Vec::new();
+    let mut idx = 0usize;
+    while let Some(v) = val.at(idx) {
+        if let Some(b) = value_to_u64(v) {
+            if b <= 255 {
+                bytes.push(b as u8);
             }
-        })
-        .unwrap_or_default()
+        }
+        idx += 1;
+    }
+    String::from_utf8(bytes).unwrap_or_default()
 }
 
-fn extract_bytes_as_string(val: &SValue, field: &str) -> String {
-    val.at(field)
-        .map(|v| match v {
-            SValue::Primitive(subxt::ext::scale_value::Primitive::String(s)) => s.clone(),
-            _ => {
-                let mut bytes = Vec::new();
-                let mut i = 0u32;
-                while let Some(b) = v.at(i) {
-                    if let Some(n) = b.as_u128() {
-                        bytes.push(n as u8);
-                    }
-                    i += 1;
-                }
-                String::from_utf8(bytes).unwrap_or_default()
-            }
-        })
-        .unwrap_or_default()
+fn extract_identity_field<C: Clone>(val: &Value<C>, field: &str) -> String {
+    match val.at(field) {
+        Some(v) => value_to_string(v),
+        None => String::new(),
+    }
 }
 
 pub async fn get_identity(endpoint: &str, address: &str) -> Result<IdentityInfo, BttError> {
@@ -86,13 +78,13 @@ pub async fn get_identity(endpoint: &str, address: &str) -> Result<IdentityInfo,
 
             Ok(IdentityInfo {
                 address: address.to_string(),
-                name: extract_bytes_as_string(&decoded, "name"),
-                url: extract_bytes_as_string(&decoded, "url"),
-                description: extract_bytes_as_string(&decoded, "description"),
-                image: extract_bytes_as_string(&decoded, "image"),
-                discord: extract_bytes_as_string(&decoded, "discord"),
-                github_repo: extract_bytes_as_string(&decoded, "github_repo"),
-                github_username: extract_bytes_as_string(&decoded, "github_username"),
+                name: extract_identity_field(&decoded, "name"),
+                url: extract_identity_field(&decoded, "url"),
+                description: extract_identity_field(&decoded, "description"),
+                image: extract_identity_field(&decoded, "image"),
+                discord: extract_identity_field(&decoded, "discord"),
+                github_repo: extract_identity_field(&decoded, "github_repo"),
+                github_username: extract_identity_field(&decoded, "github_username"),
             })
         }
         None => Ok(IdentityInfo {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod chain;
 pub mod dynamic_decode;
+pub mod identity;
 pub mod password_file;
 pub mod paths;
 pub mod skill;

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,13 +210,15 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 let result = commands::identity::set_identity(
                     &endpoint,
                     &name,
-                    &display_name,
-                    &url,
-                    &description,
-                    &image,
-                    &discord,
-                    &github_repo,
-                    &github_username,
+                    commands::identity::SetIdentityFields {
+                        display_name: &display_name,
+                        url: &url,
+                        description: &description,
+                        image: &image,
+                        discord: &discord,
+                        github_repo: &github_repo,
+                        github_username: &github_username,
+                    },
                 )
                 .await?;
                 output::print_success(&result, pretty);

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,43 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 let result = commands::wallet_keys::verify(&message, &signature, &ss58)?;
                 output::print_success(&result, pretty);
             }
+            WalletAction::GetIdentity { ss58 } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result =
+                    commands::identity::get_identity(&endpoint, &ss58).await?;
+                output::print_success(&result, pretty);
+            }
+            WalletAction::SetIdentity {
+                name,
+                display_name,
+                url,
+                description,
+                image,
+                discord,
+                github_repo,
+                github_username,
+            } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result = commands::identity::set_identity(
+                    &endpoint,
+                    &name,
+                    &display_name,
+                    &url,
+                    &description,
+                    &image,
+                    &discord,
+                    &github_repo,
+                    &github_username,
+                )
+                .await?;
+                output::print_success(&result, pretty);
+            }
             WalletAction::Cleanup {
                 dry_run,
                 wallet,


### PR DESCRIPTION
## Summary
- `btt wallet get-identity --ss58 <address>` — read-only query of on-chain identity
- `btt wallet set-identity --name <wallet> [--display-name ...] [--url ...] ...` — coldkey-signing to set identity
- Reads/writes `SubtensorModule::Identities` storage map

## Changes
- `src/commands/identity.rs` — new module (+186 lines)
- `src/commands/mod.rs` — register module
- `src/cli.rs` — `GetIdentity` and `SetIdentity` variants under `WalletAction`
- `src/main.rs` — dispatch for both commands

## Test plan
- [ ] CI green (clippy, tests, verify, dep-audit)
- [ ] `get-identity` tested against mainnet (read-only, any known validator address)
- [ ] `set-identity` testnet verification pending (requires testnet TAO)

Closes #106.

[cryptid]