### PR TITLE
axon set: advertise miner/validator endpoint

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,12 @@ pub enum Command {
         action: SubnetAction,
     },
 
+    /// Axon endpoint advertising for miners and validators
+    Axon {
+        #[command(subcommand)]
+        action: AxonAction,
+    },
+
     /// Utility commands (unit conversion, latency test)
     Utils {
         #[command(subcommand)]
@@ -125,6 +131,41 @@ pub enum UtilsAction {
     /// the round-trip time in milliseconds. Uses the same connection
     /// path as all other btt commands.
     Latency,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AxonAction {
+    /// Advertise the axon endpoint (IP, port) for a hotkey on a subnet.
+    ///
+    /// Submits a `SubtensorModule::serve_axon` extrinsic. Hotkey-signing
+    /// (lower risk than coldkey). Other nodes use this endpoint to
+    /// discover and connect to the miner or validator.
+    Set {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Hotkey name
+        #[arg(long, default_value = "default")]
+        hotkey: String,
+        /// Subnet id
+        #[arg(long)]
+        netuid: u16,
+        /// IP address (IPv4 or IPv6)
+        #[arg(long)]
+        ip: String,
+        /// Port number
+        #[arg(long)]
+        port: u16,
+        /// IP type (4 or 6). Auto-detected from the IP address if 0.
+        #[arg(long, default_value_t = 0)]
+        ip_type: u8,
+        /// Protocol identifier
+        #[arg(long, default_value_t = 4)]
+        protocol: u8,
+        /// Axon version
+        #[arg(long, default_value_t = 0)]
+        version: u32,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/axon.rs
+++ b/src/commands/axon.rs
@@ -1,0 +1,129 @@
+use std::net::IpAddr;
+use std::time::Duration;
+
+use serde::Serialize;
+use sp_core::Pair as PairTrait;
+use subxt::ext::scale_value::Value as SValue;
+
+use crate::commands::stake::Sr25519Signer;
+use crate::commands::wallet_keys::load_hotkey_pair;
+use crate::error::BttError;
+use crate::rpc;
+
+#[derive(Serialize)]
+pub struct AxonResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub action: String,
+    pub hotkey: String,
+    pub netuid: u16,
+}
+
+pub struct AxonParams<'a> {
+    pub wallet: &'a str,
+    pub hotkey: &'a str,
+    pub netuid: u16,
+    pub ip: &'a str,
+    pub port: u16,
+    pub ip_type: u8,
+    pub protocol: u8,
+    pub version: u32,
+}
+
+pub async fn set(endpoint: &str, params: AxonParams<'_>) -> Result<AxonResult, BttError> {
+    let parsed_ip: IpAddr = params.ip
+        .parse()
+        .map_err(|e| BttError::invalid_input(format!("invalid IP address: {e}")))?;
+
+    let ip_as_u128 = match parsed_ip {
+        IpAddr::V4(v4) => u128::from(u32::from(v4)),
+        IpAddr::V6(v6) => u128::from(v6),
+    };
+
+    let actual_ip_type = match parsed_ip {
+        IpAddr::V4(_) => 4u8,
+        IpAddr::V6(_) => 6u8,
+    };
+    let ip_type = if params.ip_type == 0 { actual_ip_type } else { params.ip_type };
+
+    let pair = load_hotkey_pair(params.wallet, params.hotkey)?;
+    let hotkey_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "serve_axon",
+        vec![
+            SValue::u128(params.netuid as u128),
+            SValue::u128(params.version as u128),
+            SValue::u128(ip_as_u128),
+            SValue::u128(params.port as u128),
+            SValue::u128(ip_type as u128),
+            SValue::u128(params.protocol as u128),
+        ],
+    );
+
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(AxonResult {
+        tx_hash,
+        block: block_hash,
+        action: "serve_axon".to_string(),
+        hotkey: hotkey_ss58,
+        netuid: params.netuid,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    #[test]
+    fn ipv4_to_u128() {
+        let ip: IpAddr = "192.168.1.1".parse().expect("valid IPv4");
+        let n = match ip {
+            IpAddr::V4(v4) => u128::from(u32::from(v4)),
+            IpAddr::V6(v6) => u128::from(v6),
+        };
+        assert_eq!(n, 0xC0A80101);
+    }
+
+    #[test]
+    fn ipv6_to_u128() {
+        let ip: IpAddr = "::1".parse().expect("valid IPv6");
+        let n = match ip {
+            IpAddr::V4(v4) => u128::from(u32::from(v4)),
+            IpAddr::V6(v6) => u128::from(v6),
+        };
+        assert_eq!(n, 1);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod axon;
 pub mod chain;
 pub mod dynamic_decode;
 pub mod identity;

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -246,6 +246,17 @@ pub fn decrypt_coldkey_interactive(wallet_name: &str) -> Result<Pair, BttError> 
     Ok(pair)
 }
 
+pub(crate) fn load_hotkey_pair(wallet_name: &str, hotkey_name: &str) -> Result<Pair, BttError> {
+    let wdir = wallet_path(wallet_name)?;
+    if !wdir.exists() {
+        return Err(BttError::wallet_not_found(format!(
+            "wallet '{wallet_name}' not found at {}",
+            wdir.display()
+        )));
+    }
+    load_hotkey(&wdir, hotkey_name)
+}
+
 /// Extract an SS58 address from key file content.
 fn extract_ss58_from_content(content: &str) -> Option<String> {
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(content) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 use clap::Parser;
 use zeroize::Zeroizing;
 
-use cli::{ChainAction, Cli, Command, StakeAction, SubnetAction, UtilsAction, WalletAction};
+use cli::{AxonAction, ChainAction, Cli, Command, StakeAction, SubnetAction, UtilsAction, WalletAction};
 use commands::password_file;
 use error::BttError;
 
@@ -326,6 +326,40 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 SubnetAction::Hyperparameters { netuid } => {
                     let result =
                         commands::subnet::hyperparameters(&endpoint, netuid).await?;
+                    output::print_success(&result, pretty);
+                }
+            }
+        }
+        Command::Axon { action } => {
+            let endpoint = rpc::resolve_endpoint(
+                cli.url.as_deref(),
+                cli.network.as_deref(),
+            )?;
+            match action {
+                AxonAction::Set {
+                    name,
+                    hotkey,
+                    netuid,
+                    ip,
+                    port,
+                    ip_type,
+                    protocol,
+                    version,
+                } => {
+                    let result = commands::axon::set(
+                        &endpoint,
+                        commands::axon::AxonParams {
+                            wallet: &name,
+                            hotkey: &hotkey,
+                            netuid,
+                            ip: &ip,
+                            port,
+                            ip_type,
+                            protocol,
+                            version,
+                        },
+                    )
+                    .await?;
                     output::print_success(&result, pretty);
                 }
             }


### PR DESCRIPTION
## Summary
- `btt axon set --name <wallet> --hotkey <name> --netuid <N> --ip <addr> --port <port>`
- Hotkey-signing (lower risk than coldkey operations)
- Submits `SubtensorModule::serve_axon` with auto-detected IP type (v4/v6)
- Exposes `load_hotkey_pair` as `pub(crate)` for hotkey-signing commands

## Changes
- `src/commands/axon.rs` — new module (+129 lines, 2 IP conversion tests)
- `src/commands/wallet_keys.rs` — `pub(crate) fn load_hotkey_pair`
- `src/commands/mod.rs` — register module
- `src/cli.rs` — `AxonAction::Set` with IP, port, protocol, version params
- `src/main.rs` — dispatch for `Command::Axon`

## Test plan
- [ ] CI green
- [ ] Testnet verification pending (requires registered hotkey on a subnet)

Partial close of #116 (reset not yet implemented).

[cryptid]