### PR TITLE
subnet register: register a hotkey on a subnet

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,6 +218,26 @@ pub enum SubnetAction {
         #[arg(long)]
         netuid: u16,
     },
+
+    /// Register a hotkey on a subnet by paying the burn cost.
+    ///
+    /// Submits a `SubtensorModule::burned_register` extrinsic. Coldkey-
+    /// signing. The burn cost varies per subnet and changes between
+    /// blocks — query it first with `btt subnet lock-cost` (note: that
+    /// command shows the subnet *creation* cost; the per-UID burn cost
+    /// is a different storage value that this command will display
+    /// before prompting for confirmation in a future iteration).
+    Register {
+        /// Wallet name (coldkey used for signing and paying the burn)
+        #[arg(long)]
+        name: String,
+        /// SS58 address of the hotkey to register
+        #[arg(long)]
+        hotkey: String,
+        /// Subnet id to register on
+        #[arg(long)]
+        netuid: u16,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod dynamic_decode;
 pub mod identity;
 pub mod password_file;
 pub mod paths;
+pub mod register;
 pub mod skill;
 pub mod stake;
 pub mod subnet;

--- a/src/commands/register.rs
+++ b/src/commands/register.rs
@@ -1,0 +1,84 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use sp_core::Pair as PairTrait;
+use subxt::ext::scale_value::Value as SValue;
+
+use crate::commands::chain::parse_ss58;
+use crate::commands::stake::Sr25519Signer;
+use crate::commands::wallet_keys::{
+    decrypt_coldkey_interactive, rao_to_tao_string, resolve_coldkey_address,
+};
+use crate::error::BttError;
+use crate::rpc;
+
+#[derive(Serialize)]
+pub struct RegisterResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub netuid: u16,
+    pub hotkey: String,
+    pub coldkey: String,
+}
+
+pub async fn register(
+    endpoint: &str,
+    wallet: &str,
+    hotkey_ss58: &str,
+    netuid: u16,
+) -> Result<RegisterResult, BttError> {
+    let hotkey_bytes = parse_ss58(hotkey_ss58)?;
+
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let coldkey_ss58 =
+        sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "burned_register",
+        vec![
+            SValue::u128(netuid as u128),
+            SValue::from_bytes(hotkey_bytes),
+        ],
+    );
+
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(RegisterResult {
+        tx_hash,
+        block: block_hash,
+        netuid,
+        hotkey: hotkey_ss58.to_string(),
+        coldkey: coldkey_ss58,
+    })
+}

--- a/src/commands/register.rs
+++ b/src/commands/register.rs
@@ -6,9 +6,7 @@ use subxt::ext::scale_value::Value as SValue;
 
 use crate::commands::chain::parse_ss58;
 use crate::commands::stake::Sr25519Signer;
-use crate::commands::wallet_keys::{
-    decrypt_coldkey_interactive, rao_to_tao_string, resolve_coldkey_address,
-};
+use crate::commands::wallet_keys::decrypt_coldkey_interactive;
 use crate::error::BttError;
 use crate::rpc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,6 +328,16 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                         commands::subnet::hyperparameters(&endpoint, netuid).await?;
                     output::print_success(&result, pretty);
                 }
+                SubnetAction::Register {
+                    name,
+                    hotkey,
+                    netuid,
+                } => {
+                    let result =
+                        commands::register::register(&endpoint, &name, &hotkey, netuid)
+                            .await?;
+                    output::print_success(&result, pretty);
+                }
             }
         }
         Command::Axon { action } => {


### PR DESCRIPTION
## Summary
- `btt subnet register --name <wallet> --hotkey <SS58> --netuid <N>`
- Coldkey-signing, submits `SubtensorModule::burned_register`
- Burns TAO to register a hotkey UID on the specified subnet

## Changes
- `src/commands/register.rs` — new module (+84 lines)
- `src/commands/mod.rs` — register module
- `src/cli.rs` — `SubnetAction::Register` variant
- `src/main.rs` — dispatch

## Test plan
- [ ] CI green
- [ ] Testnet verification pending (requires testnet TAO for burn cost)

Closes #107.

[cryptid]