### PR TITLE
wallet swap-hotkey: replace a hotkey for a coldkey

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -439,6 +439,23 @@ pub enum WalletAction {
         ss58: String,
     },
 
+    /// Replace a hotkey associated with this wallet's coldkey.
+    ///
+    /// Submits a `SubtensorModule::swap_hotkey` extrinsic. Coldkey-
+    /// signing. The old hotkey's registrations, stakes, and weights
+    /// transfer to the new hotkey.
+    SwapHotkey {
+        /// Wallet name (coldkey used for signing)
+        #[arg(long)]
+        name: String,
+        /// SS58 address of the old hotkey to replace
+        #[arg(long)]
+        old_hotkey: String,
+        /// SS58 address of the new hotkey to install
+        #[arg(long)]
+        new_hotkey: String,
+    },
+
     /// Query on-chain identity for an SS58 address.
     ///
     /// Reads `SubtensorModule::Identities` storage map. Returns name,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod register;
 pub mod skill;
 pub mod stake;
 pub mod subnet;
+pub mod swap_hotkey;
 pub mod utils;
 pub mod wallet;
 pub mod wallet_keys;

--- a/src/commands/swap_hotkey.rs
+++ b/src/commands/swap_hotkey.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use sp_core::Pair as PairTrait;
+use subxt::ext::scale_value::Value as SValue;
+
+use crate::commands::chain::parse_ss58;
+use crate::commands::stake::Sr25519Signer;
+use crate::commands::wallet_keys::decrypt_coldkey_interactive;
+use crate::error::BttError;
+use crate::rpc;
+
+#[derive(Serialize)]
+pub struct SwapHotkeyResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub old_hotkey: String,
+    pub new_hotkey: String,
+    pub coldkey: String,
+}
+
+pub async fn swap_hotkey(
+    endpoint: &str,
+    wallet: &str,
+    old_hotkey: &str,
+    new_hotkey: &str,
+) -> Result<SwapHotkeyResult, BttError> {
+    let old_bytes = parse_ss58(old_hotkey)?;
+    let new_bytes = parse_ss58(new_hotkey)?;
+
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let coldkey_ss58 =
+        sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "swap_hotkey",
+        vec![
+            SValue::from_bytes(old_bytes),
+            SValue::from_bytes(new_bytes),
+        ],
+    );
+
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(SwapHotkeyResult {
+        tx_hash,
+        block: block_hash,
+        old_hotkey: old_hotkey.to_string(),
+        new_hotkey: new_hotkey.to_string(),
+        coldkey: coldkey_ss58,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,21 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 let result = commands::wallet_keys::verify(&message, &signature, &ss58)?;
                 output::print_success(&result, pretty);
             }
+            WalletAction::SwapHotkey {
+                name,
+                old_hotkey,
+                new_hotkey,
+            } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result = commands::swap_hotkey::swap_hotkey(
+                    &endpoint, &name, &old_hotkey, &new_hotkey,
+                )
+                .await?;
+                output::print_success(&result, pretty);
+            }
             WalletAction::GetIdentity { ss58 } => {
                 let endpoint = rpc::resolve_endpoint(
                     cli.url.as_deref(),


### PR DESCRIPTION
## Summary
- `btt wallet swap-hotkey --name <wallet> --old-hotkey <SS58> --new-hotkey <SS58>`
- Coldkey-signing, submits `SubtensorModule::swap_hotkey`
- Old hotkey's registrations, stakes, and weights transfer to the new hotkey

## Changes
- `src/commands/swap_hotkey.rs` — new module (+83 lines)
- `src/commands/mod.rs` — register module
- `src/cli.rs` — `WalletAction::SwapHotkey` variant
- `src/main.rs` — dispatch

## Test plan
- [ ] CI green
- [ ] Testnet verification pending (requires registered hotkey to swap)

Closes #104.

[cryptid]