### PR TITLE
stake claim: claim accumulated alpha dividends

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -733,6 +733,19 @@ pub enum StakeAction {
         #[arg(long)]
         take: u16,
     },
+
+    /// Claim accumulated alpha dividends from subnets. Coldkey-signing.
+    ///
+    /// Submits `SubtensorModule::claim_root` with up to 5 subnet IDs.
+    /// Harvests any pending alpha emissions on the specified subnets.
+    Claim {
+        /// Wallet name (coldkey used for signing)
+        #[arg(long)]
+        wallet: String,
+        /// Subnet IDs to claim from (up to 5, comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        netuids: Vec<u16>,
+    },
 }
 
 #[cfg(test)]

--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -907,6 +907,80 @@ pub async fn swap_stake(
     })
 }
 
+// ── claim ─────────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct ClaimResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub netuids: Vec<u16>,
+}
+
+pub async fn claim(
+    endpoint: &str,
+    wallet: &str,
+    netuids: &[u16],
+) -> Result<ClaimResult, BttError> {
+    if netuids.is_empty() {
+        return Err(BttError::invalid_input(
+            "provide at least one netuid to claim from",
+        ));
+    }
+    if netuids.len() > 5 {
+        return Err(BttError::invalid_input(
+            "claim_root supports at most 5 subnet IDs per call",
+        ));
+    }
+
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let netuid_values: Vec<SValue> = netuids.iter().map(|n| SValue::u128(*n as u128)).collect();
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "claim_root",
+        vec![SValue::unnamed_composite(netuid_values)],
+    );
+
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(ClaimResult {
+        tx_hash,
+        block: block_hash,
+        netuids: netuids.to_vec(),
+    })
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────
 
 /// Resolve an address from either a wallet name or a direct SS58 string.

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,11 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                     .await?;
                     output::print_success(&result, pretty);
                 }
+                StakeAction::Claim { wallet, netuids } => {
+                    let result =
+                        commands::stake::claim(&endpoint, &wallet, &netuids).await?;
+                    output::print_success(&result, pretty);
+                }
             }
         }
         Command::Subnet { action } => {


### PR DESCRIPTION
## Summary
- `btt stake claim --wallet <name> --netuids 1,2,3`
- Coldkey-signing, submits `SubtensorModule::claim_root`
- Claims accumulated alpha dividends from up to 5 subnets per call

## Changes
- `src/commands/stake.rs` — `claim()` function + `ClaimResult` struct (+74 lines)
- `src/cli.rs` — `StakeAction::Claim` with `--netuids` comma-delimited list
- `src/main.rs` — dispatch

## Test plan
- [ ] CI green
- [ ] Testnet verification pending (requires staked wallet with accrued emissions)

Closes #113.

[cryptid]