### PR TITLE
axon reset: clear endpoint for a hotkey

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,6 +166,23 @@ pub enum AxonAction {
         #[arg(long, default_value_t = 0)]
         version: u32,
     },
+
+    /// Clear the axon endpoint for a hotkey on a subnet. Hotkey-signing.
+    ///
+    /// Submits `SubtensorModule::serve_axon` with zeroed IP, port,
+    /// protocol, and version fields, effectively de-advertising the
+    /// endpoint.
+    Reset {
+        /// Wallet name
+        #[arg(long)]
+        name: String,
+        /// Hotkey name
+        #[arg(long, default_value = "default")]
+        hotkey: String,
+        /// Subnet id
+        #[arg(long)]
+        netuid: u16,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/axon.rs
+++ b/src/commands/axon.rs
@@ -103,6 +103,69 @@ pub async fn set(endpoint: &str, params: AxonParams<'_>) -> Result<AxonResult, B
     })
 }
 
+pub async fn reset(
+    endpoint: &str,
+    wallet: &str,
+    hotkey_name: &str,
+    netuid: u16,
+) -> Result<AxonResult, BttError> {
+    let pair = load_hotkey_pair(wallet, hotkey_name)?;
+    let hotkey_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "serve_axon",
+        vec![
+            SValue::u128(netuid as u128),
+            SValue::u128(0u128),
+            SValue::u128(0u128),
+            SValue::u128(0u128),
+            SValue::u128(0u128),
+            SValue::u128(0u128),
+        ],
+    );
+
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(&tx, &signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok(AxonResult {
+        tx_hash,
+        block: block_hash,
+        action: "reset_axon".to_string(),
+        hotkey: hotkey_ss58,
+        netuid,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::IpAddr;

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,6 +487,15 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                     .await?;
                     output::print_success(&result, pretty);
                 }
+                AxonAction::Reset {
+                    name,
+                    hotkey,
+                    netuid,
+                } => {
+                    let result =
+                        commands::axon::reset(&endpoint, &name, &hotkey, netuid).await?;
+                    output::print_success(&result, pretty);
+                }
             }
         }
         Command::Utils { action } => match action {


### PR DESCRIPTION
## Summary
- `btt axon reset --name <wallet> --hotkey <name> --netuid <N>`
- Hotkey-signing, submits `serve_axon` with zeroed fields
- Completes #116 (set was merged in PR #133)

## Changes
- `src/commands/axon.rs` — `reset()` function (+63 lines)
- `src/cli.rs` — `AxonAction::Reset` variant
- `src/main.rs` — dispatch

## Test plan
- [ ] CI green

Closes #116.

[cryptid]