### PR TITLE
wallet swap-coldkey: announce, execute, clear, dispute

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -473,6 +473,43 @@ pub enum WalletAction {
         new_hotkey: String,
     },
 
+    /// Announce intent to swap this wallet's coldkey. Coldkey-signing.
+    /// Starts a 5-day (7200 block) waiting period before execution.
+    SwapColdkeyAnnounce {
+        /// Wallet name (current coldkey, used for signing)
+        #[arg(long)]
+        name: String,
+        /// SS58 address of the new coldkey to swap to
+        #[arg(long)]
+        new_coldkey: String,
+    },
+
+    /// Execute a previously announced coldkey swap. Coldkey-signing.
+    /// Only succeeds after the 5-day waiting period has elapsed.
+    SwapColdkeyExecute {
+        /// Wallet name (current coldkey, used for signing)
+        #[arg(long)]
+        name: String,
+    },
+
+    /// Cancel a pending coldkey swap announcement. Coldkey-signing.
+    SwapColdkeyClear {
+        /// Wallet name (current coldkey, used for signing)
+        #[arg(long)]
+        name: String,
+    },
+
+    /// Dispute another account's pending coldkey swap. Coldkey-signing.
+    /// Requires governance authority (senate membership).
+    SwapColdkeyDispute {
+        /// Wallet name (disputer's coldkey, used for signing)
+        #[arg(long)]
+        name: String,
+        /// SS58 address of the coldkey whose swap is being disputed
+        #[arg(long)]
+        target: String,
+    },
+
     /// Query on-chain identity for an SS58 address.
     ///
     /// Reads `SubtensorModule::Identities` storage map. Returns name,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod register;
 pub mod skill;
 pub mod stake;
 pub mod subnet;
+pub mod swap_coldkey;
 pub mod swap_hotkey;
 pub mod utils;
 pub mod wallet;

--- a/src/commands/swap_coldkey.rs
+++ b/src/commands/swap_coldkey.rs
@@ -1,0 +1,171 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use sp_core::Pair as PairTrait;
+use subxt::ext::scale_value::Value as SValue;
+
+use crate::commands::chain::parse_ss58;
+use crate::commands::stake::Sr25519Signer;
+use crate::commands::wallet_keys::decrypt_coldkey_interactive;
+use crate::error::BttError;
+use crate::rpc;
+
+#[derive(Serialize)]
+pub struct SwapColdkeyResult {
+    pub tx_hash: String,
+    pub block: String,
+    pub action: String,
+    pub old_coldkey: String,
+    pub new_coldkey: String,
+}
+
+pub async fn announce(
+    endpoint: &str,
+    wallet: &str,
+    new_coldkey_ss58: &str,
+) -> Result<SwapColdkeyResult, BttError> {
+    let new_bytes = parse_ss58(new_coldkey_ss58)?;
+
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let old_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "schedule_coldkey_swap",
+        vec![SValue::from_bytes(new_bytes)],
+    );
+
+    let (tx_hash, block_hash) = submit_and_finalize(&api, &tx, &signer).await?;
+
+    Ok(SwapColdkeyResult {
+        tx_hash,
+        block: block_hash,
+        action: "schedule_coldkey_swap".to_string(),
+        old_coldkey: old_ss58,
+        new_coldkey: new_coldkey_ss58.to_string(),
+    })
+}
+
+pub async fn execute(
+    endpoint: &str,
+    wallet: &str,
+) -> Result<SwapColdkeyResult, BttError> {
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let old_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "execute_coldkey_swap",
+        vec![],
+    );
+
+    let (tx_hash, block_hash) = submit_and_finalize(&api, &tx, &signer).await?;
+
+    Ok(SwapColdkeyResult {
+        tx_hash,
+        block: block_hash,
+        action: "execute_coldkey_swap".to_string(),
+        old_coldkey: old_ss58.clone(),
+        new_coldkey: old_ss58,
+    })
+}
+
+pub async fn clear(
+    endpoint: &str,
+    wallet: &str,
+) -> Result<SwapColdkeyResult, BttError> {
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let old_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "cancel_coldkey_swap",
+        vec![],
+    );
+
+    let (tx_hash, block_hash) = submit_and_finalize(&api, &tx, &signer).await?;
+
+    Ok(SwapColdkeyResult {
+        tx_hash,
+        block: block_hash,
+        action: "cancel_coldkey_swap".to_string(),
+        old_coldkey: old_ss58.clone(),
+        new_coldkey: String::new(),
+    })
+}
+
+pub async fn dispute(
+    endpoint: &str,
+    wallet: &str,
+    target_coldkey_ss58: &str,
+) -> Result<SwapColdkeyResult, BttError> {
+    let target_bytes = parse_ss58(target_coldkey_ss58)?;
+
+    let pair = decrypt_coldkey_interactive(wallet)?;
+    let disputer_ss58 = sp_core::crypto::AccountId32::from(PairTrait::public(&pair)).to_string();
+    let signer = Sr25519Signer::new(pair);
+
+    let api = rpc::connect(endpoint).await?;
+
+    let tx = subxt::dynamic::tx(
+        "SubtensorModule",
+        "dispute_coldkey_swap",
+        vec![SValue::from_bytes(target_bytes)],
+    );
+
+    let (tx_hash, block_hash) = submit_and_finalize(&api, &tx, &signer).await?;
+
+    Ok(SwapColdkeyResult {
+        tx_hash,
+        block: block_hash,
+        action: "dispute_coldkey_swap".to_string(),
+        old_coldkey: disputer_ss58,
+        new_coldkey: target_coldkey_ss58.to_string(),
+    })
+}
+
+async fn submit_and_finalize(
+    api: &subxt::OnlineClient<subxt::PolkadotConfig>,
+    tx: &subxt::tx::DynamicPayload<Vec<SValue>>,
+    signer: &Sr25519Signer,
+) -> Result<(String, String), BttError> {
+    let mut tx_client = tokio::time::timeout(Duration::from_secs(120), api.tx())
+        .await
+        .map_err(|_| BttError::submission_failed("resolving transaction client timed out"))?
+        .map_err(|e| {
+            BttError::submission_failed(format!("failed to resolve transaction client: {e}"))
+        })?;
+
+    let progress = tokio::time::timeout(
+        Duration::from_secs(120),
+        tx_client.sign_and_submit_then_watch_default(tx, signer),
+    )
+    .await
+    .map_err(|_| BttError::submission_failed("transaction submission timed out"))?
+    .map_err(|e| BttError::submission_failed(format!("failed to submit transaction: {e}")))?;
+
+    let tx_hash = format!("{:?}", progress.extrinsic_hash());
+
+    let in_block = tokio::time::timeout(Duration::from_secs(120), progress.wait_for_finalized())
+        .await
+        .map_err(|_| BttError::submission_failed("waiting for finalization timed out"))?
+        .map_err(|e| BttError::submission_failed(format!("transaction failed: {e}")))?;
+
+    let block_hash = format!("{:?}", in_block.block_hash());
+
+    in_block
+        .wait_for_success()
+        .await
+        .map_err(|e| BttError::submission_failed(format!("extrinsic failed: {e}")))?;
+
+    Ok((tx_hash, block_hash))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,40 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 let result = commands::wallet_keys::verify(&message, &signature, &ss58)?;
                 output::print_success(&result, pretty);
             }
+            WalletAction::SwapColdkeyAnnounce { name, new_coldkey } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result =
+                    commands::swap_coldkey::announce(&endpoint, &name, &new_coldkey).await?;
+                output::print_success(&result, pretty);
+            }
+            WalletAction::SwapColdkeyExecute { name } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result = commands::swap_coldkey::execute(&endpoint, &name).await?;
+                output::print_success(&result, pretty);
+            }
+            WalletAction::SwapColdkeyClear { name } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result = commands::swap_coldkey::clear(&endpoint, &name).await?;
+                output::print_success(&result, pretty);
+            }
+            WalletAction::SwapColdkeyDispute { name, target } => {
+                let endpoint = rpc::resolve_endpoint(
+                    cli.url.as_deref(),
+                    cli.network.as_deref(),
+                )?;
+                let result =
+                    commands::swap_coldkey::dispute(&endpoint, &name, &target).await?;
+                output::print_success(&result, pretty);
+            }
             WalletAction::SwapHotkey {
                 name,
                 old_hotkey,


### PR DESCRIPTION
## Summary
- `btt wallet swap-coldkey-announce` — start 5-day rotation
- `btt wallet swap-coldkey-execute` — execute after waiting period
- `btt wallet swap-coldkey-clear` — cancel pending swap
- `btt wallet swap-coldkey-dispute` — governance dispute (senate)
- All coldkey-signing
- Shared `submit_and_finalize` helper extracts repeated pattern

## Changes
- `src/commands/swap_coldkey.rs` — new module (+171 lines)
- `src/commands/mod.rs` — register module
- `src/cli.rs` — 4 new `WalletAction` variants (+37 lines)
- `src/main.rs` — dispatch for all 4 (+34 lines)

## Test plan
- [ ] CI green
- [ ] Announce+clear can be tested on testnet (no waiting period needed)
- [ ] Execute requires 5-day wait — impractical for CI, verify extrinsic construction
- [ ] Dispute requires senate access — verify extrinsic construction only

Closes #105.

[cryptid]