### PR TITLE
wallet/stake: add --password-file for transfer/stake add/remove/transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ btt wallet regen-hotkey --name alice [--hotkey default] \
 btt wallet regen-hotkey --name alice [--hotkey default] \
     --seed 0x<64 hex chars> [--force]
 
+# Transfer free-balance TAO from this wallet's coldkey to a destination
+# SS58 address. Constructs a `Balances::transfer_keep_alive` extrinsic.
+btt wallet transfer --name alice --dest <ss58> --amount <tao> \
+                    [--password-file <path>]
+
 # Sign a message with the wallet's coldkey (default).
 btt wallet sign --name alice --message "hello" [--password-file <path>]
 
@@ -137,7 +142,7 @@ btt stake list --ss58 <ss58_address>
 # Stake TAO from a coldkey to a hotkey on a subnet.
 # --hotkey takes the hotkey's SS58 address, not a wallet hotkey name.
 btt stake add --wallet alice --hotkey <hotkey_ss58> \
-              --netuid <n> --amount <tao>
+              --netuid <n> --amount <tao> [--password-file <path>]
 
 # Unstake alpha back to the coldkey. Pick exactly one denomination:
 #   --amount-alpha <n>  submit n alpha directly
@@ -145,11 +150,18 @@ btt stake add --wallet alice --hotkey <hotkey_ss58> \
 #                       subnet pool spot price at the head block
 #   --all               unstake the full current alpha balance
 btt stake remove --wallet alice --hotkey <hotkey_ss58> \
-                 --netuid <n> --amount-alpha <n>
+                 --netuid <n> --amount-alpha <n> [--password-file <path>]
 btt stake remove --wallet alice --hotkey <hotkey_ss58> \
-                 --netuid <n> --amount-tao <n>
+                 --netuid <n> --amount-tao <n> [--password-file <path>]
 btt stake remove --wallet alice --hotkey <hotkey_ss58> \
-                 --netuid <n> --all
+                 --netuid <n> --all [--password-file <path>]
+
+# Transfer staked alpha to a different coldkey without unstaking. Signs
+# with the current coldkey; the alpha lands on the destination coldkey
+# paired to the same hotkey and netuid.
+btt stake transfer --wallet alice --dest-coldkey <ss58> \
+                   --hotkey <hotkey_ss58> --netuid <n> --amount <tao> \
+                   [--password-file <path>]
 ```
 
 Since dTAO, 1 alpha is not 1 TAO on any non-root subnet. `stake remove`
@@ -200,7 +212,8 @@ to leave the legacy location in place and let both tools share it.
 ## Non-interactive automation
 
 Commands that prompt for the coldkey password (`wallet create`, `wallet
-new-coldkey`, `wallet regen-coldkey`, `wallet sign`) accept a `--password-file
+new-coldkey`, `wallet regen-coldkey`, `wallet sign`, `wallet transfer`,
+`stake add`, `stake remove`, `stake transfer`) accept a `--password-file
 <path>` flag for CI and scripted use. The file's first line (minus the
 trailing newline) is taken as the password.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -592,6 +592,16 @@ pub enum WalletAction {
         /// Amount of TAO to transfer (decimal, e.g. 1.5)
         #[arg(long)]
         amount: f64,
+        /// Read coldkey password from file at <path>. For non-interactive
+        /// automation only. The file's first line (up to but not including
+        /// the trailing newline) is taken as the password. Security note:
+        /// anyone who can read the file can recover your password. Ensure
+        /// the file is mode 0600, on a tmpfs (/dev/shm) if possible, and
+        /// shredded immediately after use. Do not use this with mainnet
+        /// wallets unless your filesystem, process listing, and shell
+        /// history are all under your control.
+        #[arg(long, value_name = "PATH")]
+        password_file: Option<String>,
     },
 
     /// Sign a message with a wallet key
@@ -792,6 +802,16 @@ pub enum StakeAction {
         /// Amount in TAO (e.g. 10.5)
         #[arg(long)]
         amount: f64,
+        /// Read coldkey password from file at <path>. For non-interactive
+        /// automation only. The file's first line (up to but not including
+        /// the trailing newline) is taken as the password. Security note:
+        /// anyone who can read the file can recover your password. Ensure
+        /// the file is mode 0600, on a tmpfs (/dev/shm) if possible, and
+        /// shredded immediately after use. Do not use this with mainnet
+        /// wallets unless your filesystem, process listing, and shell
+        /// history are all under your control.
+        #[arg(long, value_name = "PATH")]
+        password_file: Option<String>,
     },
 
     /// Unstake alpha from a hotkey back to the coldkey on a subnet.
@@ -833,6 +853,16 @@ pub enum StakeAction {
         /// Conflicts with --amount-alpha and --amount-tao.
         #[arg(long, default_value_t = false)]
         all: bool,
+        /// Read coldkey password from file at <path>. For non-interactive
+        /// automation only. The file's first line (up to but not including
+        /// the trailing newline) is taken as the password. Security note:
+        /// anyone who can read the file can recover your password. Ensure
+        /// the file is mode 0600, on a tmpfs (/dev/shm) if possible, and
+        /// shredded immediately after use. Do not use this with mainnet
+        /// wallets unless your filesystem, process listing, and shell
+        /// history are all under your control.
+        #[arg(long, value_name = "PATH")]
+        password_file: Option<String>,
     },
 
     /// Move stake from one hotkey/subnet to another without unstake+restake.
@@ -883,6 +913,16 @@ pub enum StakeAction {
         /// Amount in TAO
         #[arg(long)]
         amount: f64,
+        /// Read coldkey password from file at <path>. For non-interactive
+        /// automation only. The file's first line (up to but not including
+        /// the trailing newline) is taken as the password. Security note:
+        /// anyone who can read the file can recover your password. Ensure
+        /// the file is mode 0600, on a tmpfs (/dev/shm) if possible, and
+        /// shredded immediately after use. Do not use this with mainnet
+        /// wallets unless your filesystem, process listing, and shell
+        /// history are all under your control.
+        #[arg(long, value_name = "PATH")]
+        password_file: Option<String>,
     },
 
     /// Swap alpha between two subnets via the dTAO AMM.

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -90,6 +90,11 @@ btt wallet sign --name <name> --message "<msg>" [--use-hotkey] \
 # Verify a signature against an SS58 address
 btt wallet verify --message "<msg>" --signature 0x... --ss58 <address>
 
+# Transfer free-balance TAO from this wallet's coldkey to a destination
+# SS58 address. `Balances::transfer_keep_alive`. Coldkey-signing.
+btt wallet transfer --name <name> --dest <ss58> --amount <TAO> \
+  [--password-file <path>]
+
 # Reap stale `.tmp.*`, `.bak.*`, and `.lock.*` entries left under the
 # wallets directory by crashed or interrupted `wallet create` runs.
 # Uses a strict reserved-prefix grammar match, never follows symlinks,
@@ -159,16 +164,26 @@ btt stake list --wallet <name>
 btt stake list --ss58 <address>
 
 # Add stake. add_stake.amount_staked is TaoBalance, so --amount is in TAO.
-btt stake add --wallet <name> --hotkey <ss58> --netuid <u16> --amount <TAO>
+btt stake add --wallet <name> --hotkey <ss58> --netuid <u16> --amount <TAO> \
+  [--password-file <path>]
 
 # Remove stake. remove_stake.amount_unstaked is AlphaBalance, so the
 # amount is in alpha. Pick one of:
 #   --amount-alpha <N>   Submit N alpha directly.
 #   --amount-tao   <N>   Convert ~N TAO -> alpha via head-block price.
 #   --all                Unstake the full current alpha balance.
-btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --amount-alpha <ALPHA>
-btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --amount-tao <TAO>
-btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --all
+btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --amount-alpha <ALPHA> \
+  [--password-file <path>]
+btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --amount-tao <TAO> \
+  [--password-file <path>]
+btt stake remove --wallet <name> --hotkey <ss58> --netuid <u16> --all \
+  [--password-file <path>]
+
+# Transfer staked alpha to a different coldkey without unstaking.
+# `SubtensorModule::transfer_stake`. Coldkey-signing.
+btt stake transfer --wallet <name> --dest-coldkey <ss58> \
+  --hotkey <ss58> --netuid <u16> --amount <TAO> \
+  [--password-file <path>]
 ```
 
 Before signing a `remove --all`, btt cross-checks the decrypted keypair's

--- a/src/commands/stake.rs
+++ b/src/commands/stake.rs
@@ -80,8 +80,8 @@ impl subxt::tx::Signer<PolkadotConfig> for Sr25519Signer {
 use crate::commands::chain::parse_ss58;
 use crate::commands::dynamic_decode::{extract_account_id_field, value_to_u64};
 use crate::commands::wallet_keys::{
-    decrypt_coldkey_interactive, rao_to_tao_string, resolve_coldkey_address, tao_to_rao,
-    RAO_PER_TAO,
+    decrypt_coldkey, decrypt_coldkey_interactive, rao_to_tao_string, resolve_coldkey_address,
+    tao_to_rao, RAO_PER_TAO,
 };
 use crate::error::BttError;
 use crate::rpc;
@@ -372,6 +372,7 @@ pub async fn add(
     hotkey: &str,
     netuid: u16,
     amount_tao: f64,
+    password: Option<&str>,
 ) -> Result<StakeTxResult, BttError> {
     let amount_rao = tao_to_rao(amount_tao)?;
     if amount_rao == 0 {
@@ -382,7 +383,7 @@ pub async fn add(
 
     let hotkey_bytes = parse_ss58(hotkey)?;
 
-    let pair = decrypt_coldkey_interactive(wallet)?;
+    let pair = decrypt_coldkey(wallet, password)?;
     let signer = Sr25519Signer::new(pair);
 
     let api = rpc::connect(endpoint).await?;
@@ -437,11 +438,12 @@ pub async fn remove(
     hotkey: &str,
     netuid: u16,
     source: RemoveAmount,
+    password: Option<&str>,
 ) -> Result<StakeTxResult, BttError> {
     let hotkey_bytes = parse_ss58(hotkey)?;
 
     // Decrypt first so a wrong password fails fast, before any RPC work.
-    let pair = decrypt_coldkey_interactive(wallet)?;
+    let pair = decrypt_coldkey(wallet, password)?;
 
     // Cross-check the decrypted pair against coldkeypub.txt (M-3). The
     // public key baked into the cold wallet directory is the canonical
@@ -757,6 +759,7 @@ pub async fn transfer_stake(
     hotkey: &str,
     netuid: u16,
     amount_tao: f64,
+    password: Option<&str>,
 ) -> Result<TransferStakeResult, BttError> {
     let amount_rao = tao_to_rao(amount_tao)?;
     if amount_rao == 0 {
@@ -768,7 +771,7 @@ pub async fn transfer_stake(
     let dest_bytes = parse_ss58(dest_coldkey)?;
     let hotkey_bytes = parse_ss58(hotkey)?;
 
-    let pair = decrypt_coldkey_interactive(wallet)?;
+    let pair = decrypt_coldkey(wallet, password)?;
     let signer = Sr25519Signer::new(pair);
 
     let api = rpc::connect(endpoint).await?;

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -8,7 +8,7 @@ use subxt::ext::scale_value::Value as SValue;
 
 use crate::commands::chain::parse_ss58;
 use crate::commands::stake::Sr25519Signer;
-use crate::commands::wallet_keys::{decrypt_coldkey_interactive, rao_to_tao_string, tao_to_rao};
+use crate::commands::wallet_keys::{decrypt_coldkey, rao_to_tao_string, tao_to_rao};
 use crate::error::BttError;
 use crate::rpc;
 
@@ -27,6 +27,7 @@ pub async fn transfer(
     wallet: &str,
     dest: &str,
     amount_tao: f64,
+    password: Option<&str>,
 ) -> Result<TransferResult, BttError> {
     let amount_rao = tao_to_rao(amount_tao)?;
     if amount_rao == 0 {
@@ -37,7 +38,7 @@ pub async fn transfer(
 
     let dest_bytes = parse_ss58(dest)?;
 
-    let pair = decrypt_coldkey_interactive(wallet)?;
+    let pair = decrypt_coldkey(wallet, password)?;
     let from_ss58 = AccountId32::from(PairTrait::public(&pair)).to_ss58check();
     let signer = Sr25519Signer::new(pair);
 

--- a/src/commands/wallet_keys.rs
+++ b/src/commands/wallet_keys.rs
@@ -246,6 +246,41 @@ pub fn decrypt_coldkey_interactive(wallet_name: &str) -> Result<Pair, BttError> 
     Ok(pair)
 }
 
+/// Decrypt the coldkey for a wallet, using a caller-supplied password if
+/// given and falling back to an interactive prompt otherwise. This is the
+/// non-interactive-capable counterpart to `decrypt_coldkey_interactive`.
+///
+/// Callers reading the password from a `--password-file` flag resolve the
+/// file contents upstream (in the CLI dispatch layer) and pass the resolved
+/// string into `Some(...)` here; the file-reading, permission-checking, and
+/// BOM-stripping logic lives in `commands::password_file`, not here.
+///
+/// When `password` is `None` the behavior is exactly
+/// `decrypt_coldkey_interactive`: sniff the envelope, prompt via rpassword,
+/// load the coldkey.
+pub fn decrypt_coldkey(wallet_name: &str, password: Option<&str>) -> Result<Pair, BttError> {
+    match password {
+        None => decrypt_coldkey_interactive(wallet_name),
+        Some(pw) => {
+            let wdir = wallet_path(wallet_name)?;
+            if !wdir.exists() {
+                return Err(BttError::wallet_not_found(format!(
+                    "wallet '{wallet_name}' not found at {}",
+                    wdir.display()
+                )));
+            }
+            let coldkey_path = wdir.join("coldkey");
+            if !coldkey_path.exists() {
+                return Err(BttError::wallet_not_found(format!(
+                    "coldkey file not found for wallet '{wallet_name}'"
+                )));
+            }
+            sniff_nacl_envelope(&coldkey_path)?;
+            load_coldkey(&wdir, pw)
+        }
+    }
+}
+
 pub(crate) fn load_hotkey_pair(wallet_name: &str, hotkey_name: &str) -> Result<Pair, BttError> {
     let wdir = wallet_path(wallet_name)?;
     if !wdir.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,13 +145,30 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                 name,
                 dest,
                 amount,
+                password_file,
             } => {
                 let endpoint = rpc::resolve_endpoint(
                     cli.url.as_deref(),
                     cli.network.as_deref(),
                 )?;
-                let result =
-                    commands::transfer::transfer(&endpoint, &name, &dest, amount).await?;
+                // When `--password-file` is omitted, pass `None` so the
+                // command prompts interactively — mirroring the pre-#147
+                // behavior byte-for-byte. Only when the flag is set do we
+                // resolve the file via `password_file::read_password_file`
+                // and pass the resolved password down.
+                let password = match password_file.as_deref() {
+                    Some(path) => Some(password_file::read_password_file(path)?),
+                    None => None,
+                };
+                let password_ref = password.as_ref().map(|p| p.as_str());
+                let result = commands::transfer::transfer(
+                    &endpoint,
+                    &name,
+                    &dest,
+                    amount,
+                    password_ref,
+                )
+                .await?;
                 output::print_success(&result, pretty);
             }
             WalletAction::Sign {
@@ -318,13 +335,20 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                     hotkey,
                     netuid,
                     amount,
+                    password_file,
                 } => {
+                    let password = match password_file.as_deref() {
+                        Some(path) => Some(password_file::read_password_file(path)?),
+                        None => None,
+                    };
+                    let password_ref = password.as_ref().map(|p| p.as_str());
                     let result = commands::stake::add(
                         &endpoint,
                         &wallet,
                         &hotkey,
                         netuid,
                         amount,
+                        password_ref,
                     )
                     .await?;
                     output::print_success(&result, pretty);
@@ -336,6 +360,7 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                     amount_alpha,
                     amount_tao,
                     all,
+                    password_file,
                 } => {
                     let source = match (amount_alpha, amount_tao, all) {
                         (Some(a), None, false) => commands::stake::RemoveAmount::Alpha(a),
@@ -354,12 +379,18 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                             ));
                         }
                     };
+                    let password = match password_file.as_deref() {
+                        Some(path) => Some(password_file::read_password_file(path)?),
+                        None => None,
+                    };
+                    let password_ref = password.as_ref().map(|p| p.as_str());
                     let result = commands::stake::remove(
                         &endpoint,
                         &wallet,
                         &hotkey,
                         netuid,
                         source,
+                        password_ref,
                     )
                     .await?;
                     output::print_success(&result, pretty);
@@ -392,9 +423,21 @@ async fn run(cli: Cli) -> Result<(), BttError> {
                     hotkey,
                     netuid,
                     amount,
+                    password_file,
                 } => {
+                    let password = match password_file.as_deref() {
+                        Some(path) => Some(password_file::read_password_file(path)?),
+                        None => None,
+                    };
+                    let password_ref = password.as_ref().map(|p| p.as_str());
                     let result = commands::stake::transfer_stake(
-                        &endpoint, &wallet, &dest_coldkey, &hotkey, netuid, amount,
+                        &endpoint,
+                        &wallet,
+                        &dest_coldkey,
+                        &hotkey,
+                        netuid,
+                        amount,
+                        password_ref,
                     )
                     .await?;
                     output::print_success(&result, pretty);


### PR DESCRIPTION
## Summary
- Extends `--password-file` (already wired for `wallet create` / `new-coldkey` / `regen-coldkey` / `sign`) to the four remaining coldkey-signing write-path commands: `wallet transfer`, `stake add`, `stake remove`, `stake transfer`.
- The interactive rpassword path is preserved byte-for-byte when the flag is absent — existing workflows unchanged.
- Reuses the existing `commands::password_file::read_password_file` for file resolution (0o600 check, 64 KiB cap, leading-BOM strip).
- New `wallet_keys::decrypt_coldkey(wallet, Option<&str>)` helper handles both None (prompt) and Some (direct load) — callers pass `Option<&str>` and no longer call `decrypt_coldkey_interactive` themselves.
- No hidden flags: the flag is listed in `--help`, in `btt skill`, and in the README per the transparency rule.

Closes #147.

## Motivation
Four coldkey-signing commands that write to chain (`wallet transfer`, `stake add`, `stake remove`, `stake transfer`) forced an interactive rpassword prompt on `/dev/tty`, with no non-interactive alternative. This blocked all CI and scripted workflows — the PTY-driver workaround at `moorkh/cryptid:tools/pty-transfer.py` exists solely to paper over this gap.

Neeraj flagged on 2026-04-19 that this state is wild and should be fixed. The fix is a straightforward extension of infrastructure that already exists for the other four `$NACL`-envelope-decrypting commands.

## Test plan
- [x] `cargo check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [ ] CI: full test matrix
- [ ] btcli-compat vectors (ascii, empty, utf8-combining, long, high-bytes, shell-meta) all green — the same `password_file::read_password_file` is exercised for every flagged command, so the existing `wallet create` coverage transitively validates the new callers
- [ ] manual smoke: `btt wallet transfer --name cryptid-test --dest 5G17hNWQBp4p9AoQWuJ83FxWwXdFEW7uwrGaa6V4KQhpKM5c --amount 1.0 --password-file /dev/shm/btt-pw --network test` against live testnet (cryptid is standing by to run this immediately post-merge to fund the STAO inflation PoC)

## Scope not included
- Other coldkey-signing commands (`wallet swap-hotkey`, `wallet swap-coldkey-*`, `wallet set-identity`, `stake move`, `stake swap`, `stake claim`, `subnet register`, `liquidity add/remove/modify`) still use `decrypt_coldkey_interactive`. Extending to those is mechanical and can follow in a separate PR once this lands and the `decrypt_coldkey` helper is battle-tested.
- No new unit tests — the password-file reading path is already covered by `password_file.rs` tests, and the new dispatch glue is straightforward plumbing. If a reviewer wants an integration test that actually round-trips through the CLI, I can add one.

_— cryptid_